### PR TITLE
feat: upgrade to v1.5.3 with lazy export plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,131 @@
 # CAD Simple Viewer Example
 
-This is an example application that demonstrates how to use the `@mlightcad/cad-simple-viewer` package to display DXF and DWG files in a web browser.
+A vanilla TypeScript demo that shows how to embed [`@mlightcad/cad-simple-viewer`](https://github.com/mlightcad/cad-viewer/tree/main/packages/cad-simple-viewer) in a web page: open DXF/DWG files, create a sample drawing, register custom commands, and lazy-load HTML/PDF/SVG export plugins.
 
-[**🌐 Live Demo**](https://mlightcad.github.io/cad-simple-viewer-example/)
+[**Live demo**](https://mlightcad.github.io/cad-simple-viewer-example/)
 
 ## Features
 
-- 📁 Open one DWG/DXF file
-- ✏️ Create one drawing
-- 📄 Export the current drawing as a self-contained HTML file (`chtml` command)
+- **Local files** — Open `.dxf` / `.dwg` via the file picker
+- **New drawing** — Create a sample drawing with predefined entities (`DocCreator`)
+- **Custom command** — Demo ellipse command (`ellipsedemo`)
+- **Lazy export plugins** — HTML (`chtml`), PDF (`cpdf`), SVG (`csvg`) load on first use
+- **Browser-only** — Parsing and rendering run in the browser (Web Workers + WebAssembly for DWG)
 
-## Development
+## Prerequisites
+
+- Node.js **≥ 20** and pnpm **≥ 10**
+
+## Getting started
 
 ```bash
-# Install dependencies
 pnpm install
-
-# Start development server
-pnpm dev
-
-# Build for production
-pnpm build
-
-# Preview production build
-pnpm preview
+pnpm dev      # Vite dev server (default http://localhost:5173)
+pnpm build    # Typecheck + production build
+pnpm preview  # Serve dist/
 ```
+
+The build copies parser workers and `viewer-runtime.iife.js` into `dist/assets/` (see `vite.config.ts`).
 
 ## Usage
 
-### Basic Usage
+1. Start the dev server and open the URL shown in the terminal.
+2. **Open** — Choose a `.dxf` or `.dwg` file, or click **New** to create the sample drawing.
+3. After a file is opened successfully, **HTML**, **PDF**, and **SVG** export buttons appear. Plugins are fetched on first export, so the first run may take a moment.
+4. Run the custom ellipse command from the viewer command line: `ellipsedemo`.
 
-Firstly, add the following dependencies into your `package.json`.
+Toast messages at the top report success or errors. The window title updates when a document is activated.
 
-- @mlightcad/cad-simple-viewer
-- @mlightcad/data-model
+## Supported formats
 
-Secondly, add one contain element for cad-simple-viewer.
+| Format | Notes |
+|--------|--------|
+| **DXF** | Parsed in a Web Worker (`dxf-parser-worker.js`) |
+| **DWG** | LibreDWG WebAssembly via `libredwg-parser-worker.js` |
+
+## Plugin system (HTML / PDF / SVG export)
+
+Export commands moved out of `cad-simple-viewer` into separate npm packages. This example registers them **lazily** so they are not in the initial bundle until the user exports.
+
+| Package | Plugin name | Trigger commands | Purpose |
+|---------|-------------|------------------|---------|
+| `@mlightcad/cad-html-plugin` | `HtmlPlugin` | `chtml` | Export drawing to offline HTML |
+| `@mlightcad/cad-pdf-plugin` | `PdfPlugin` | `cpdf`, `ipdf` | Export to PDF / import vector PDF |
+| `@mlightcad/cad-svg-plugin` | `SvgPlugin` | `csvg` | Export drawing to SVG |
+
+See the [Plugin System wiki](https://github.com/mlightcad/cad-viewer/wiki/Plugin-System) for how to build and register your own plugins.
+
+### Registration (this example)
+
+After `AcApDocManager.createInstance()`, register lazy plugins on `pluginManager`:
+
+```typescript
+import { registerLazyHtmlPlugin } from '@mlightcad/cad-html-plugin'
+import { registerLazyPdfPlugin } from '@mlightcad/cad-pdf-plugin'
+import { registerLazySvgPlugin } from '@mlightcad/cad-svg-plugin'
+import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
+
+AcApDocManager.createInstance({
+  container: document.getElementById('cad-container')!,
+  autoResize: true,
+  webworkerFileUrls: {
+    mtextRender: './assets/mtext-renderer-worker.js',
+    dxfParser: './assets/dxf-parser-worker.js',
+    dwgParser: './assets/libredwg-parser-worker.js'
+  },
+  // Required for HTML export — must match where viewer-runtime.iife.js is served
+  htmlViewerRuntimeUrl: './assets/viewer-runtime.iife.js'
+})
+
+const pm = AcApDocManager.instance.pluginManager
+registerLazyHtmlPlugin(pm)
+registerLazyPdfPlugin(pm)
+registerLazySvgPlugin(pm)
+```
+
+### Run export commands
+
+After a document is loaded, trigger export via UI or API:
+
+```typescript
+AcApDocManager.instance.sendStringToExecute('chtml')
+AcApDocManager.instance.sendStringToExecute('cpdf')
+AcApDocManager.instance.sendStringToExecute('csvg')
+```
+
+`sendStringToExecute` loads the matching lazy plugin automatically on first use. You do not need to call `loadByTrigger` unless you want to preload before execution.
+
+### Static assets for HTML export
+
+HTML export embeds `viewer-runtime.iife.js` from `@mlightcad/cad-html-plugin` (not from `cad-simple-viewer`). Copy it next to your workers and set `htmlViewerRuntimeUrl` to that path.
+
+`vite-plugin-static-copy` in `vite.config.ts` copies:
+
+- `./node_modules/@mlightcad/data-model/dist/dxf-parser-worker.js` → `assets/`
+- `./node_modules/@mlightcad/cad-simple-viewer/dist/*-worker.js` → `assets/`
+- `./node_modules/@mlightcad/cad-html-plugin/dist/viewer-runtime.iife.js` → `assets/`
+
+If `viewer-runtime.iife.js` is missing or the URL is wrong, the dev server may return `index.html` instead and the exported HTML will fail with `Unexpected token '<'`.
+
+## Basic integration
+
+### Dependencies
+
+```json
+{
+  "dependencies": {
+    "@mlightcad/cad-simple-viewer": "^1.5.3",
+    "@mlightcad/data-model": "^1.8.1",
+    "@mlightcad/cad-html-plugin": "^1.5.3",
+    "@mlightcad/cad-pdf-plugin": "^1.5.3",
+    "@mlightcad/cad-svg-plugin": "^1.5.3"
+  }
+}
+```
+
+Add export plugins only if you need those features.
+
+### HTML container
 
 ```html
 <body>
@@ -43,170 +133,59 @@ Secondly, add one contain element for cad-simple-viewer.
 </body>
 ```
 
-Thirdly, initialize the viewer in your entry point:
+### Open a file
 
 ```typescript
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
 import { AcDbOpenDatabaseOptions } from '@mlightcad/data-model'
 
-const container = document.getElementById('cad-container') as HTMLDivElement
+// ... createInstance + registerLazy*Plugin as above ...
 
-AcApDocManager.createInstance({
-  container,
-  autoResize: true,
-  webworkerFileUrls: {
-    mtextRender: './assets/mtext-renderer-worker.js',
-    dxfParser: './assets/dxf-parser-worker.js',
-    dwgParser: './assets/libredwg-parser-worker.js'
-  },
-  htmlViewerRuntimeUrl: './assets/viewer-runtime.iife.js'
-})
-
-// Read the file content
 const fileContent = await readFile(file)
-
-// Set database options
 const options: AcDbOpenDatabaseOptions = {
   minimumChunkSize: 1000,
   readOnly: true
 }
 
-// Open the document
-const success = await AcApDocManager.instance.openDocument(
-  file.name,
-  fileContent,
-  options
-)
-
-// Your application logic here...
+await AcApDocManager.instance.openDocument(file.name, fileContent, options)
 ```
 
-Finally, copy static assets to the `dist/assets` folder.
+## What this example demonstrates
 
-Web workers are used to parse DXF/DWG files and render MTEXT entities so the UI is not blocked. The HTML viewer runtime is required when exporting drawings to standalone HTML files. You can copy the following files to `dist/assets` manually:
+| Topic | Implementation |
+|-------|----------------|
+| Document manager | `AcApDocManager.createInstance({ container, baseUrl, webworkerFileUrls, htmlViewerRuntimeUrl })` |
+| Local open | `openDocument(name, ArrayBuffer, options)` |
+| Custom commands | `commandManager.addCommand(...)` — see `src/ellipseCmd.ts` |
+| Plugins | `registerLazyHtmlPlugin` / `registerLazyPdfPlugin` / `registerLazySvgPlugin` |
+| Export UI | `sendStringToExecute('chtml' \| 'cpdf' \| 'csvg')` |
+| Workers & assets | `webworkerFileUrls`, static copy in Vite |
 
-- `./node_modules/@mlightcad/data-model/dist/dxf-parser-worker.js`
-- `./node_modules/@mlightcad/cad-simple-viewer/dist/libredwg-parser-worker.js`
-- `./node_modules/@mlightcad/cad-simple-viewer/dist/mtext-renderer-worker.js`
-- `./node_modules/@mlightcad/cad-simple-viewer/dist/viewer-runtime.iife.js`
+Lazy initialization: `AcApDocManager` is created on first file open or **New**, not at page load.
 
-However, `vite-plugin-static-copy` is recommended to make your life easier.
+## Project structure
 
-```typescript
-import { resolve } from 'path'
-import { defineConfig } from 'vite'
-import { viteStaticCopy } from 'vite-plugin-static-copy'
+| Path | Role |
+|------|------|
+| `index.html` | Layout, file/new/export controls, canvas container |
+| `src/main.ts` | `CadViewerApp` — viewer, plugins, export buttons |
+| `src/ellipseCmd.ts` | Custom `ellipsedemo` command |
+| `src/docCreator.ts` | Sample drawing factory for **New** |
+| `vite.config.ts` | `base: './'`, copies workers + `viewer-runtime.iife.js` |
 
-export default defineConfig(() => {
-  return {
-    base: './',
-    build: {
-      modulePreload: false,
-      rollupOptions: {
-        // Main entry point for the app
-        input: {
-          main: resolve(__dirname, 'index.html')
-        }
-      }
-    },
-    plugins: [
-      viteStaticCopy({
-        targets: [
-          {
-            src: './node_modules/@mlightcad/data-model/dist/dxf-parser-worker.js',
-            dest: 'assets'
-          },
-          {
-            src: './node_modules/@mlightcad/cad-simple-viewer/dist/*-worker.js',
-            dest: 'assets'
-          },
-          {
-            src: './node_modules/@mlightcad/cad-simple-viewer/dist/viewer-runtime.iife.js',
-            dest: 'assets'
-          }
-        ]
-      })
-    ]
-  }
-})
-```
+## Beyond a viewer
 
-### Export to HTML
+`cad-simple-viewer` supports modifying drawings in real time (add/edit entities). The API patterns are similar to AutoCAD RealDWG; see [`realdwg-web`](https://mlightcad.github.io/realdwg-web/) and class [`DocCreator`](./src/docCreator.ts).
 
-`cad-simple-viewer` includes a built-in `chtml` command that exports the active drawing as a **self-contained HTML file**. The snapshot and viewer runtime are inlined into a single file, so the result can be opened directly in a browser (including via `file://`).
+### Custom commands
 
-Trigger the export after a document is loaded:
+- [Command wiki](https://github.com/mlightcad/cad-viewer/wiki/Command)
+- [Example: `ellipseCmd.ts`](./src/ellipseCmd.ts)
 
-```typescript
-AcApDocManager.instance.sendStringToExecute('chtml')
-```
+## Related packages
 
-For export to work, two things are required:
-
-1. **Serve `viewer-runtime.iife.js`** — copy it to your static assets (see `vite.config.ts` above) and set `htmlViewerRuntimeUrl` when creating `AcApDocManager`. At export time the runtime is fetched and embedded into the HTML. If this file is missing, the dev server may return `index.html` instead, and the exported file will fail to open with `Unexpected token '<'`.
-2. **Match URLs** — `htmlViewerRuntimeUrl` must point to the same path where the runtime file is served (for example `./assets/viewer-runtime.iife.js`).
-
-### Beyond a Viewer
-
-While `cad-simple-viewer` doesn't support saving drawings to DWG/DXF files, it provides comprehensive support for **modifying drawings in real-time**. You can add, edit, and delete entities within the drawing, and the viewer will automatically update to reflect these changes.
-
-When you modify entities, you're working directly with the underlying drawing database. The viewer automatically detects these changes and updates the display accordingly. This real-time synchronization ensures that:
-
-- All modifications are immediately visible
-- The command stack properly tracks changes for undo/redo operations. This will be implemented soon.
-
-This capability makes `cad-simple-viewer` suitable for applications that need to not only display CAD files but also allow users to interact with and modify the drawing content.
-
-**Important Note**: The usage patterns in `cad-simple-viewer` are **very similar to AutoCAD RealDWG**. If you're familiar with AutoCAD RealDWG development, you'll find the API structure and workflow nearly identical. The main difference is that we use the [**realdwg-web API**](https://mlightcad.github.io/realdwg-web/) instead of the native RealDWG libraries.
-
-#### Example: Adding Entities
-
-The following code demonstrates how to add entities, following the same pattern you'd use in AutoCAD RealDWG:
-
-```typescript
-import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
-import { AcDbLine, AcDbCircle, AcDbText, AcGePoint3d, AcGeVector3d } from '@mlightcad/data-model'
-
-// Get the current document (same as RealDWG)
-const doc = AcApDocManager.instance.curDocument
-if (!doc) return
-
-// Get the model space (identical to RealDWG pattern)
-const modelSpace = doc.database.modelSpace
-
-// Add a line (same constructor and property setting as RealDWG)
-const startPoint = new AcGePoint3d(0, 0, 0)
-const endPoint = new AcGePoint3d(100, 100, 0)
-const line = new AcDbLine(startPoint, endPoint)
-line.layer = '0' // Set layer (same property name as RealDWG)
-line.color = 1 // Red color (same color index as RealDWG)
-modelSpace.appendEntity(line)
-
-// Add a circle (identical API to RealDWG)
-const centerPoint = new AcGePoint3d(50, 50, 0)
-const radius = 25
-const circle = new AcDbCircle(centerPoint, radius)
-circle.layer = '0'
-circle.color = 2 // Yellow color
-modelSpace.appendEntity(circle)
-
-// Add text (same constructor pattern as RealDWG)
-const textPoint = new AcGePoint3d(0, -50, 0)
-const text = new AcDbText(textPoint, 'Sample Text', 10) // position, text, height
-text.layer = '0'
-text.color = 3 // Green color
-modelSpace.appendEntity(text)
-```
-
-Please refer to class [DocCreator](./src/docCreator.ts) to get one full example to create one new drawing.
-
-
-#### Example: Custom Command
-
-Commands are the primary way users interact with the CAD-Viewer. Each command represents a specific operation, such as drawing a line, creating a circle, zooming, or selecting objects. CAD-Viewer supports creating custom commands to extend functionalities of CAD-Viewer.
-
-- [Wiki Page](https://github.com/mlightcad/cad-viewer/wiki/Command): Introduce how to create one custom command.
-- [Example Code](./src/ellipseCmd.ts): One demo command to create one ellipse by center, major axis, and minor radius.
+- [`@mlightcad/cad-viewer`](https://github.com/mlightcad/cad-viewer/tree/main/packages/cad-viewer) — Full Vue UI with built-in lazy plugin registration
+- [`cad-simple-viewer-example` (monorepo)](https://github.com/mlightcad/cad-viewer/tree/main/packages/cad-simple-viewer-example) — Richer toolbar/sidebar demo in the main repo
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -102,7 +102,33 @@
       }
       
       .file-input-container.loaded .button-group {
-        gap: 1rem;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+        max-width: min(90vw, 520px);
+        justify-content: flex-start;
+      }
+
+      .file-input-container.loading-file .button-container.entry-actions {
+        display: none;
+      }
+
+      /* Must beat .button-container { display: flex } on the same element */
+      .button-container.export-actions {
+        display: none;
+      }
+
+      .file-input-container.show-export .button-container.export-actions {
+        display: flex;
+      }
+
+      .file-fab:disabled {
+        opacity: 0.45;
+        cursor: not-allowed;
+      }
+
+      .file-fab:disabled:hover {
+        background: #23272f;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.18);
       }
       
       .button-container {
@@ -135,7 +161,7 @@
     <div class="viewer-container">
       <div class="file-input-container" id="fileInputContainer">
         <div class="button-group">
-          <div class="button-container">
+          <div class="button-container entry-actions" id="openButtonContainer">
             <label class="file-fab" id="fileFab">
               <input type="file" id="fileInputElement" accept=".dxf,.dwg" />
               <svg width="40" height="40" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" class="file-icon">
@@ -145,13 +171,40 @@
             </label>
             <div class="file-fab-label">Open</div>
           </div>
-          <div class="button-container">
+          <div class="button-container entry-actions" id="newButtonContainer">
             <button class="file-fab" id="newDrawingButton">
               <svg width="40" height="40" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" class="file-icon">
                 <path d="M10 3v14M3 10h14"/>
               </svg>
             </button>
             <div class="file-fab-label">New</div>
+          </div>
+          <div class="button-container export-actions">
+            <button class="file-fab" id="exportHtmlButton" type="button" disabled title="Export HTML (chtml)">
+              <svg width="40" height="40" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" class="file-icon">
+                <path d="M4 4h12v12H4z"/>
+                <path d="M7 8h6M7 11h4"/>
+              </svg>
+            </button>
+            <div class="file-fab-label">HTML</div>
+          </div>
+          <div class="button-container export-actions">
+            <button class="file-fab" id="exportPdfButton" type="button" disabled title="Export PDF (cpdf)">
+              <svg width="40" height="40" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" class="file-icon">
+                <path d="M5 4h7l3 3v9H5z"/>
+                <path d="M12 4v3h3"/>
+              </svg>
+            </button>
+            <div class="file-fab-label">PDF</div>
+          </div>
+          <div class="button-container export-actions">
+            <button class="file-fab" id="exportSvgButton" type="button" disabled title="Export SVG (csvg)">
+              <svg width="40" height="40" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" class="file-icon">
+                <path d="M4 6h12v8H4z"/>
+                <path d="M7 9l2 2 4-4"/>
+              </svg>
+            </button>
+            <div class="file-fab-label">SVG</div>
           </div>
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -9,15 +9,14 @@
     "url": "https://github.com/mlightcad/cad-simple-viewer-example"
   },
   "scripts": {
-    "build": "vue-tsc && vite build",
+    "build": "tsc && vite build",
     "dev": "vite",
     "preview": "vite preview"
   },
   "devDependencies": {
     "typescript": "^5.5.2",
     "vite": "^5.4.19",
-    "vite-plugin-static-copy": "^3.1.1",
-    "vue-tsc": "^2.1.6"
+    "vite-plugin-static-copy": "^3.1.1"
   },
   "dependencies": {
     "@mlightcad/cad-html-plugin": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "vue-tsc": "^2.1.6"
   },
   "dependencies": {
-    "@mlightcad/cad-simple-viewer": "1.5.1",
-    "@mlightcad/data-model": "1.7.40"
+    "@mlightcad/cad-html-plugin": "1.5.3",
+    "@mlightcad/cad-pdf-plugin": "1.5.3",
+    "@mlightcad/cad-svg-plugin": "1.5.3",
+    "@mlightcad/cad-simple-viewer": "1.5.3",
+    "@mlightcad/data-model": "1.8.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,21 @@ importers:
 
   .:
     dependencies:
+      '@mlightcad/cad-html-plugin':
+        specifier: 1.5.3
+        version: 1.5.3(@mlightcad/cad-simple-viewer@1.5.3(@mlightcad/data-model@1.8.1)(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.8.1)(@mlightcad/three-renderer@1.5.3(@mlightcad/data-model@1.8.1)(@mlightcad/mtext-renderer@0.10.16(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(three@0.172.0)
+      '@mlightcad/cad-pdf-plugin':
+        specifier: 1.5.3
+        version: 1.5.3(@mlightcad/cad-simple-viewer@1.5.3(@mlightcad/data-model@1.8.1)(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/cad-svg-plugin@1.5.3(@mlightcad/cad-simple-viewer@1.5.3(@mlightcad/data-model@1.8.1)(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.8.1)(@mlightcad/mtext-parser@1.4.1))(@mlightcad/data-model@1.8.1)
       '@mlightcad/cad-simple-viewer':
-        specifier: 1.5.1
-        version: 1.5.1(@mlightcad/cad-html-exporter@1.5.1(@mlightcad/data-model@1.7.40)(@mlightcad/three-renderer@1.5.1(@mlightcad/data-model@1.7.40)(@mlightcad/mtext-renderer@0.10.15(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(three@0.172.0))(@mlightcad/data-model@1.7.40)(@mlightcad/mtext-renderer@0.10.15(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0)
+        specifier: 1.5.3
+        version: 1.5.3(@mlightcad/data-model@1.8.1)(lodash-es@4.17.21)(three@0.172.0)
+      '@mlightcad/cad-svg-plugin':
+        specifier: 1.5.3
+        version: 1.5.3(@mlightcad/cad-simple-viewer@1.5.3(@mlightcad/data-model@1.8.1)(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.8.1)(@mlightcad/mtext-parser@1.4.1)
       '@mlightcad/data-model':
-        specifier: 1.7.40
-        version: 1.7.40
+        specifier: 1.8.1
+        version: 1.8.1
     devDependencies:
       typescript:
         specifier: ^5.5.2
@@ -192,66 +201,71 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
-  '@mlightcad/cad-html-exporter@1.5.1':
-    resolution: {integrity: sha512-G7jFEDzlJVyq3dUfzGPFXSQuMqOCGYPjQUK6GSeFEMJGB2A2XC2HwzoHYJcL6enDpaCe1WokstYZlm+zCdyedw==}
+  '@mlightcad/cad-html-plugin@1.5.3':
+    resolution: {integrity: sha512-gBJvJ98GZ1zvsRI3gIW/dFn0taDs5vW2/zalfD0bMJnjz6FjumJSKUmm/Y7YT5EEI/wr844Oq0Dhh02lKVZRpg==}
     peerDependencies:
-      '@mlightcad/data-model': ^1.7.40
-      '@mlightcad/three-renderer': ^1.5.1
+      '@mlightcad/cad-simple-viewer': 1.5.3
+      '@mlightcad/data-model': ^1.8.1
+      '@mlightcad/three-renderer': 1.5.3
       three: ^0.172.0
 
-  '@mlightcad/cad-simple-viewer@1.5.1':
-    resolution: {integrity: sha512-kW+ILc3GF5xWaBN3WMS/G3qr7X9n1lKDUhnsfcBLVzwjl3jHs5l8p8fuk/AwheSWTtH5q9y8NwQNcfkaKL29dA==}
+  '@mlightcad/cad-pdf-plugin@1.5.3':
+    resolution: {integrity: sha512-dg/i64i9ldZxe2Rxu9fWZT0uH9yQM1RTnW77efylyIEYrRGQFzmSHcSkkDfUS5r1TyfDuUqZSJ53Dnvy5yBKag==}
     peerDependencies:
-      '@mlightcad/cad-html-exporter': ^1.5.1
-      '@mlightcad/data-model': ^1.7.40
-      '@mlightcad/mtext-renderer': ^0.10.15
+      '@mlightcad/cad-simple-viewer': 1.5.3
+      '@mlightcad/cad-svg-plugin': 1.5.3
+      '@mlightcad/data-model': ^1.8.1
+
+  '@mlightcad/cad-simple-viewer@1.5.3':
+    resolution: {integrity: sha512-Ruhs6rAk2/PCQl9ZRRcH4c+g57gmsCPijDXqixu2FAWASx0K/6aj0RHF5vaQPoZDvl8m24+dkHlxBI2iWIUr9w==}
+    peerDependencies:
+      '@mlightcad/data-model': ^1.8.1
       lodash-es: 4.17.21
       three: ^0.172.0
 
-  '@mlightcad/common@1.4.40':
-    resolution: {integrity: sha512-RQDG7j6MiwVNbCAmszNLRzOJNc/pMilPnNzS2wnVTRI9k8wtINQmvEyEJjBQGSGK7p/2gmY1JwoKjYH36izcsw==}
+  '@mlightcad/cad-svg-plugin@1.5.3':
+    resolution: {integrity: sha512-hCZyThxufebnehMXnjV+R+M+RXehTczMjy3nFvSliscLPVZEuO9cclRYTNzE+l6EayFpyqAxxnDhX6nLck/d5Q==}
+    peerDependencies:
+      '@mlightcad/cad-simple-viewer': 1.5.3
+      '@mlightcad/data-model': ^1.8.1
+      '@mlightcad/mtext-parser': ^1.4.1
 
-  '@mlightcad/data-model@1.7.40':
-    resolution: {integrity: sha512-QWJA1CyNByt68FPVv4mi1e7hsJbyNzpkII4NBuJPCwzTwSonR97ix7m2JPEftV9bq0wMCcOg0uAbrTU/zAbJNQ==}
+  '@mlightcad/common@1.5.1':
+    resolution: {integrity: sha512-qq8d/NOAWmfYPP53ySPd/gUymn/G0gUuUJeF4Igae4/S+s+BG7WGo1Tphd737bBM65KiosUf+aiMCRTNH49Q0w==}
+
+  '@mlightcad/data-model@1.8.1':
+    resolution: {integrity: sha512-XJ924pwP4jZeLybtqgoMytrtX9pJP1IDnk//QLkez+ZygP9zFsEx+bSBy0Wun7tMooeWtGcQ0EfLNVABwzte3w==}
 
   '@mlightcad/dxf-json@1.2.0':
     resolution: {integrity: sha512-pfKFSMi84wmV1C4EAq4Axq20K1+12tXGI5epggxWZE++NeZBCQM5yuQYKYD/P8oSWz3c2nFHe9KhithAKUSnfQ==}
 
-  '@mlightcad/geometry-engine@3.2.40':
-    resolution: {integrity: sha512-dAs2kaW3BlL2sDmmLoHSY78k1mv2e5LMz6GPZKhlK2j+ttk2gfVYaNPx8VSCu5txCVmSYTJVTzkn/PR+ZlBzWw==}
+  '@mlightcad/geometry-engine@3.3.1':
+    resolution: {integrity: sha512-vB00E6rs3UPSQZOuGX7SvrgSf1y8hbiykuQCSiKRC8zY4XV6Sv551aH/k+OusAKsUTJZvhw2wyidIjSRjaDxzw==}
     peerDependencies:
-      '@mlightcad/common': 1.4.40
+      '@mlightcad/common': 1.5.1
 
-  '@mlightcad/graphic-interface@3.3.40':
-    resolution: {integrity: sha512-uDO4OHmCWE/kEPCvG3fzb1H1MBi0mHkfXRZFk55lwrYrJEQccmYmfCTsHK+YvzAbrRVbWX0vpshhPya8ltCWvg==}
+  '@mlightcad/graphic-interface@3.4.1':
+    resolution: {integrity: sha512-DpBe56zzpYBFHOIdJhGLwCWRMf3rzccNeeVZ32s0iH55qNhylDPwqEHhfwlzqIRP4jXZGBG1R6N/WRdNEzKvVg==}
     peerDependencies:
-      '@mlightcad/common': 1.4.40
-      '@mlightcad/geometry-engine': 3.2.40
-
-  '@mlightcad/libredwg-converter@3.6.0':
-    resolution: {integrity: sha512-cJUyGixUqYTjTfFR7790x+8l7Dean9QPlWnsjaKw7vkhRkDYjzrl7jVqRN+ROXb1/6JgSqdpMcRZxf4Gs3AEQQ==}
-    peerDependencies:
-      '@mlightcad/data-model': 1.8.0
-
-  '@mlightcad/libredwg-web@0.7.1':
-    resolution: {integrity: sha512-jHiLB6Rktty0eJLS+/awITmTQbTrJl4U6hkzqzzbBfHzhrR38mKnQTPLuhZMyX1IcKOM0zuDOh7Fd/J7Rj6/KQ==}
+      '@mlightcad/common': 1.5.1
+      '@mlightcad/geometry-engine': 3.3.1
 
   '@mlightcad/mtext-parser@1.4.1':
     resolution: {integrity: sha512-PU7D5H/k25vZpTERabpdn5HVAs8+SBNRqgi08wRPiplxTE1eB/zBZRNRrSwHqyWx6xMeQmZ9mhh9DPNpte3gYQ==}
 
-  '@mlightcad/mtext-renderer@0.10.15':
-    resolution: {integrity: sha512-KqP00rhM9gVy5VJ6JxYLQD5wRtNHclXN7L8wfKHYicLdfSL23pDRNOCkFeFdSyUDlYlXmvuGAWgY+NvnYerQpg==}
+  '@mlightcad/mtext-renderer@0.10.16':
+    resolution: {integrity: sha512-mCDvR6fvIvK4ZxkK+P8WbEwmsJMVh3Z+AiONbPB44pE5x7ZZGFDIGr/8zLCNPZFZbFqwCkNmCeWc99r3bR6GKw==}
     peerDependencies:
       three: ^0.172.0
 
   '@mlightcad/shx-parser@1.3.2':
     resolution: {integrity: sha512-j84hqbWOVMDuepLEjVsYvxeiCXOVxHyJhl4gM4HtgXZ6ChgTLsuSnqs2bNOt2SwriTvFOsv3QLsOu2iJh857JA==}
 
-  '@mlightcad/three-renderer@1.5.1':
-    resolution: {integrity: sha512-0yPQjeL9X8tNvZfxpH29k152mHUiJ3GWRQYaCcYGTMUq6In7fERBScU0P8DFQ9n61oRB+DtP2COsXGRAe2iu6g==}
+  '@mlightcad/three-renderer@1.5.3':
+    resolution: {integrity: sha512-qdj6DkZAySBlNbCEOuMg/SBa/VfV0MJz1SzQl7WpzxTWM5kL/GqPRoMksPWAGXbZR4PAEV+Is/cB7+FqaAFG0g==}
     peerDependencies:
-      '@mlightcad/data-model': ^1.7.40
-      '@mlightcad/mtext-renderer': ^0.10.15
+      '@mlightcad/data-model': ^1.8.1
+      '@mlightcad/mtext-renderer': ^0.10.16
       '@velipso/polybool': ^1.1.1
       three: ^0.172.0
 
@@ -460,9 +474,6 @@ packages:
       picomatch:
         optional: true
 
-  fflate@0.8.3:
-    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
-
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -524,9 +535,6 @@ packages:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  mitt@3.0.1:
-    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
-
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
@@ -565,12 +573,6 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
-
-  quickselect@3.0.0:
-    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
-
-  rbush@4.0.1:
-    resolution: {integrity: sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -757,34 +759,41 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
-  '@mlightcad/cad-html-exporter@1.5.1(@mlightcad/data-model@1.7.40)(@mlightcad/three-renderer@1.5.1(@mlightcad/data-model@1.7.40)(@mlightcad/mtext-renderer@0.10.15(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(three@0.172.0)':
+  '@mlightcad/cad-html-plugin@1.5.3(@mlightcad/cad-simple-viewer@1.5.3(@mlightcad/data-model@1.8.1)(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.8.1)(@mlightcad/three-renderer@1.5.3(@mlightcad/data-model@1.8.1)(@mlightcad/mtext-renderer@0.10.16(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(three@0.172.0)':
     dependencies:
-      '@mlightcad/data-model': 1.7.40
-      '@mlightcad/three-renderer': 1.5.1(@mlightcad/data-model@1.7.40)(@mlightcad/mtext-renderer@0.10.15(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0)
-      fflate: 0.8.3
+      '@mlightcad/cad-simple-viewer': 1.5.3(@mlightcad/data-model@1.8.1)(lodash-es@4.17.21)(three@0.172.0)
+      '@mlightcad/data-model': 1.8.1
+      '@mlightcad/three-renderer': 1.5.3(@mlightcad/data-model@1.8.1)(@mlightcad/mtext-renderer@0.10.16(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0)
       three: 0.172.0
 
-  '@mlightcad/cad-simple-viewer@1.5.1(@mlightcad/cad-html-exporter@1.5.1(@mlightcad/data-model@1.7.40)(@mlightcad/three-renderer@1.5.1(@mlightcad/data-model@1.7.40)(@mlightcad/mtext-renderer@0.10.15(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(three@0.172.0))(@mlightcad/data-model@1.7.40)(@mlightcad/mtext-renderer@0.10.15(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0)':
+  '@mlightcad/cad-pdf-plugin@1.5.3(@mlightcad/cad-simple-viewer@1.5.3(@mlightcad/data-model@1.8.1)(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/cad-svg-plugin@1.5.3(@mlightcad/cad-simple-viewer@1.5.3(@mlightcad/data-model@1.8.1)(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.8.1)(@mlightcad/mtext-parser@1.4.1))(@mlightcad/data-model@1.8.1)':
     dependencies:
-      '@mlightcad/cad-html-exporter': 1.5.1(@mlightcad/data-model@1.7.40)(@mlightcad/three-renderer@1.5.1(@mlightcad/data-model@1.7.40)(@mlightcad/mtext-renderer@0.10.15(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(three@0.172.0)
-      '@mlightcad/data-model': 1.7.40
-      '@mlightcad/libredwg-converter': 3.6.0(@mlightcad/data-model@1.7.40)
-      '@mlightcad/mtext-renderer': 0.10.15(three@0.172.0)
+      '@mlightcad/cad-simple-viewer': 1.5.3(@mlightcad/data-model@1.8.1)(lodash-es@4.17.21)(three@0.172.0)
+      '@mlightcad/cad-svg-plugin': 1.5.3(@mlightcad/cad-simple-viewer@1.5.3(@mlightcad/data-model@1.8.1)(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.8.1)(@mlightcad/mtext-parser@1.4.1)
+      '@mlightcad/data-model': 1.8.1
+
+  '@mlightcad/cad-simple-viewer@1.5.3(@mlightcad/data-model@1.8.1)(lodash-es@4.17.21)(three@0.172.0)':
+    dependencies:
+      '@mlightcad/data-model': 1.8.1
       lodash-es: 4.17.21
-      mitt: 3.0.1
-      rbush: 4.0.1
       three: 0.172.0
 
-  '@mlightcad/common@1.4.40':
+  '@mlightcad/cad-svg-plugin@1.5.3(@mlightcad/cad-simple-viewer@1.5.3(@mlightcad/data-model@1.8.1)(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.8.1)(@mlightcad/mtext-parser@1.4.1)':
+    dependencies:
+      '@mlightcad/cad-simple-viewer': 1.5.3(@mlightcad/data-model@1.8.1)(lodash-es@4.17.21)(three@0.172.0)
+      '@mlightcad/data-model': 1.8.1
+      '@mlightcad/mtext-parser': 1.4.1
+
+  '@mlightcad/common@1.5.1':
     dependencies:
       loglevel: 1.9.2
 
-  '@mlightcad/data-model@1.7.40':
+  '@mlightcad/data-model@1.8.1':
     dependencies:
-      '@mlightcad/common': 1.4.40
+      '@mlightcad/common': 1.5.1
       '@mlightcad/dxf-json': 1.2.0
-      '@mlightcad/geometry-engine': 3.2.40(@mlightcad/common@1.4.40)
-      '@mlightcad/graphic-interface': 3.3.40(@mlightcad/common@1.4.40)(@mlightcad/geometry-engine@3.2.40(@mlightcad/common@1.4.40))
+      '@mlightcad/geometry-engine': 3.3.1(@mlightcad/common@1.5.1)
+      '@mlightcad/graphic-interface': 3.4.1(@mlightcad/common@1.5.1)(@mlightcad/geometry-engine@3.3.1(@mlightcad/common@1.5.1))
       iconv-lite: 0.7.0
       uid: 2.0.2
 
@@ -792,25 +801,18 @@ snapshots:
     dependencies:
       '@fxts/core': 1.17.0
 
-  '@mlightcad/geometry-engine@3.2.40(@mlightcad/common@1.4.40)':
+  '@mlightcad/geometry-engine@3.3.1(@mlightcad/common@1.5.1)':
     dependencies:
-      '@mlightcad/common': 1.4.40
+      '@mlightcad/common': 1.5.1
 
-  '@mlightcad/graphic-interface@3.3.40(@mlightcad/common@1.4.40)(@mlightcad/geometry-engine@3.2.40(@mlightcad/common@1.4.40))':
+  '@mlightcad/graphic-interface@3.4.1(@mlightcad/common@1.5.1)(@mlightcad/geometry-engine@3.3.1(@mlightcad/common@1.5.1))':
     dependencies:
-      '@mlightcad/common': 1.4.40
-      '@mlightcad/geometry-engine': 3.2.40(@mlightcad/common@1.4.40)
-
-  '@mlightcad/libredwg-converter@3.6.0(@mlightcad/data-model@1.7.40)':
-    dependencies:
-      '@mlightcad/data-model': 1.7.40
-      '@mlightcad/libredwg-web': 0.7.1
-
-  '@mlightcad/libredwg-web@0.7.1': {}
+      '@mlightcad/common': 1.5.1
+      '@mlightcad/geometry-engine': 3.3.1(@mlightcad/common@1.5.1)
 
   '@mlightcad/mtext-parser@1.4.1': {}
 
-  '@mlightcad/mtext-renderer@0.10.15(three@0.172.0)':
+  '@mlightcad/mtext-renderer@0.10.16(three@0.172.0)':
     dependencies:
       '@mlightcad/mtext-parser': 1.4.1
       '@mlightcad/shx-parser': 1.3.2
@@ -821,10 +823,10 @@ snapshots:
 
   '@mlightcad/shx-parser@1.3.2': {}
 
-  '@mlightcad/three-renderer@1.5.1(@mlightcad/data-model@1.7.40)(@mlightcad/mtext-renderer@0.10.15(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0)':
+  '@mlightcad/three-renderer@1.5.3(@mlightcad/data-model@1.8.1)(@mlightcad/mtext-renderer@0.10.16(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0)':
     dependencies:
-      '@mlightcad/data-model': 1.7.40
-      '@mlightcad/mtext-renderer': 0.10.15(three@0.172.0)
+      '@mlightcad/data-model': 1.8.1
+      '@mlightcad/mtext-renderer': 0.10.16(three@0.172.0)
       '@velipso/polybool': 1.1.1
       three: 0.172.0
 
@@ -1012,8 +1014,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
-  fflate@0.8.3: {}
-
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -1067,8 +1067,6 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
-  mitt@3.0.1: {}
-
   muggle-string@0.4.1: {}
 
   nanoid@3.3.11: {}
@@ -1095,12 +1093,6 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  quickselect@3.0.0: {}
-
-  rbush@4.0.1:
-    dependencies:
-      quickselect: 3.0.0
 
   readdirp@3.6.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,28 +33,8 @@ importers:
       vite-plugin-static-copy:
         specifier: ^3.1.1
         version: 3.1.2(vite@5.4.20)
-      vue-tsc:
-        specifier: ^2.1.6
-        version: 2.2.12(typescript@5.9.2)
 
 packages:
-
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.27.1':
-    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.28.4':
-    resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/types@7.28.4':
-    resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
-    engines: {node: '>=6.9.0'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -396,51 +376,13 @@ packages:
   '@velipso/polybool@1.1.1':
     resolution: {integrity: sha512-HlWrm/wloLkUDHPQ1AgUdXysKL3y+rqV94udU5CVTtEPci5v6WjEfozNJTOOSwCsz50ySIxJK4gABqfbx1sD7A==}
 
-  '@volar/language-core@2.4.15':
-    resolution: {integrity: sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==}
-
-  '@volar/source-map@2.4.15':
-    resolution: {integrity: sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==}
-
-  '@volar/typescript@2.4.15':
-    resolution: {integrity: sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==}
-
-  '@vue/compiler-core@3.5.21':
-    resolution: {integrity: sha512-8i+LZ0vf6ZgII5Z9XmUvrCyEzocvWT+TeR2VBUVlzIH6Tyv57E20mPZ1bCS+tbejgUgmjrEh7q/0F0bibskAmw==}
-
-  '@vue/compiler-dom@3.5.21':
-    resolution: {integrity: sha512-jNtbu/u97wiyEBJlJ9kmdw7tAr5Vy0Aj5CgQmo+6pxWNQhXZDPsRr1UWPN4v3Zf82s2H3kF51IbzZ4jMWAgPlQ==}
-
-  '@vue/compiler-vue2@2.7.16':
-    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
-
-  '@vue/language-core@2.2.12':
-    resolution: {integrity: sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@vue/shared@3.5.21':
-    resolution: {integrity: sha512-+2k1EQpnYuVuu3N7atWyG3/xoFWIVJZq4Mz8XNOdScFI0etES75fbny/oU4lKWk/577P1zmg0ioYvpGEDZ3DLw==}
-
-  alien-signals@1.0.13:
-    resolution: {integrity: sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==}
-
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
-
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -450,20 +392,10 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
-  de-indent@1.0.2:
-    resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
-
-  entities@4.5.0:
-    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
-    engines: {node: '>=0.12'}
-
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
     hasBin: true
-
-  estree-walker@2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -493,10 +425,6 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  he@1.2.0:
-    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
-    hasBin: true
 
   iconv-lite@0.7.0:
     resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
@@ -531,13 +459,6 @@ packages:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
     engines: {node: '>= 0.6.0'}
 
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
-  muggle-string@0.4.1:
-    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
-
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -555,9 +476,6 @@ packages:
   p-map@7.0.3:
     resolution: {integrity: sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==}
     engines: {node: '>=18'}
-
-  path-browserify@1.0.1:
-    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -660,29 +578,7 @@ packages:
       terser:
         optional: true
 
-  vscode-uri@3.1.0:
-    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
-
-  vue-tsc@2.2.12:
-    resolution: {integrity: sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==}
-    hasBin: true
-    peerDependencies:
-      typescript: '>=5.0.0'
-
 snapshots:
-
-  '@babel/helper-string-parser@7.27.1': {}
-
-  '@babel/helper-validator-identifier@7.27.1': {}
-
-  '@babel/parser@7.28.4':
-    dependencies:
-      '@babel/types': 7.28.4
-
-  '@babel/types@7.28.4':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -902,65 +798,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@volar/language-core@2.4.15':
-    dependencies:
-      '@volar/source-map': 2.4.15
-
-  '@volar/source-map@2.4.15': {}
-
-  '@volar/typescript@2.4.15':
-    dependencies:
-      '@volar/language-core': 2.4.15
-      path-browserify: 1.0.1
-      vscode-uri: 3.1.0
-
-  '@vue/compiler-core@3.5.21':
-    dependencies:
-      '@babel/parser': 7.28.4
-      '@vue/shared': 3.5.21
-      entities: 4.5.0
-      estree-walker: 2.0.2
-      source-map-js: 1.2.1
-
-  '@vue/compiler-dom@3.5.21':
-    dependencies:
-      '@vue/compiler-core': 3.5.21
-      '@vue/shared': 3.5.21
-
-  '@vue/compiler-vue2@2.7.16':
-    dependencies:
-      de-indent: 1.0.2
-      he: 1.2.0
-
-  '@vue/language-core@2.2.12(typescript@5.9.2)':
-    dependencies:
-      '@volar/language-core': 2.4.15
-      '@vue/compiler-dom': 3.5.21
-      '@vue/compiler-vue2': 2.7.16
-      '@vue/shared': 3.5.21
-      alien-signals: 1.0.13
-      minimatch: 9.0.5
-      muggle-string: 0.4.1
-      path-browserify: 1.0.1
-    optionalDependencies:
-      typescript: 5.9.2
-
-  '@vue/shared@3.5.21': {}
-
-  alien-signals@1.0.13: {}
-
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  balanced-match@1.0.2: {}
-
   binary-extensions@2.3.0: {}
-
-  brace-expansion@2.0.2:
-    dependencies:
-      balanced-match: 1.0.2
 
   braces@3.0.3:
     dependencies:
@@ -977,10 +820,6 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
-
-  de-indent@1.0.2: {}
-
-  entities@4.5.0: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -1008,8 +847,6 @@ snapshots:
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
 
-  estree-walker@2.0.2: {}
-
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -1032,8 +869,6 @@ snapshots:
       is-glob: 4.0.3
 
   graceful-fs@4.2.11: {}
-
-  he@1.2.0: {}
 
   iconv-lite@0.7.0:
     dependencies:
@@ -1063,12 +898,6 @@ snapshots:
 
   loglevel@1.9.2: {}
 
-  minimatch@9.0.5:
-    dependencies:
-      brace-expansion: 2.0.2
-
-  muggle-string@0.4.1: {}
-
   nanoid@3.3.11: {}
 
   normalize-path@3.0.0: {}
@@ -1079,8 +908,6 @@ snapshots:
       tiny-inflate: 1.0.3
 
   p-map@7.0.3: {}
-
-  path-browserify@1.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -1171,11 +998,3 @@ snapshots:
       rollup: 4.52.0
     optionalDependencies:
       fsevents: 2.3.3
-
-  vscode-uri@3.1.0: {}
-
-  vue-tsc@2.2.12(typescript@5.9.2):
-    dependencies:
-      '@volar/typescript': 2.4.15
-      '@vue/language-core': 2.2.12(typescript@5.9.2)
-      typescript: 5.9.2

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,7 @@
+import { registerLazyHtmlPlugin } from '@mlightcad/cad-html-plugin'
+import { registerLazyPdfPlugin } from '@mlightcad/cad-pdf-plugin'
 import { AcApDocManager, AcEdCommandStack } from '@mlightcad/cad-simple-viewer'
+import { registerLazySvgPlugin } from '@mlightcad/cad-svg-plugin'
 import { AcDbOpenDatabaseOptions } from '@mlightcad/data-model'
 import { DocCreator } from './docCreator'
 import { AcApEllipseCmd } from './ellipseCmd'
@@ -39,6 +42,7 @@ class CadViewerApp {
         })
         initializeLocale()
         this.registerCommands()
+        this.registerLazyPlugins()
         this.isInitialized = true
       } catch (error) {
         console.error('Failed to initialize CAD viewer:', error)
@@ -55,6 +59,21 @@ class CadViewerApp {
       'ellipsedemo',
       new AcApEllipseCmd()
     )
+  }
+
+  /**
+   * Registers lazy plugins that load on first use of their trigger commands.
+   *
+   * Currently registers the PDF plugin (`cpdf`, `ipdf`), the HTML export
+   * plugin (`chtml`), and the SVG export plugin (`csvg`), which are fetched
+   * only when one of those commands runs.
+   * Safe to call multiple times; registration runs once per application lifetime.
+   */
+  private registerLazyPlugins() {
+    const pluginManager = AcApDocManager.instance.pluginManager
+    registerLazyHtmlPlugin(pluginManager)
+    registerLazyPdfPlugin(pluginManager)
+    registerLazySvgPlugin(pluginManager)
   }
 
   private setupFileHandling() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,28 +7,146 @@ import { DocCreator } from './docCreator'
 import { AcApEllipseCmd } from './ellipseCmd'
 import { initializeLocale } from './i8n'
 
+/**
+ * Plugin export command names registered by the official HTML, PDF, and SVG packages.
+ *
+ * These strings are passed to {@link AcApDocManager.sendStringToExecute} and also serve
+ * as lazy-load triggers for their respective plugins.
+ *
+ * @see https://github.com/mlightcad/cad-viewer/wiki/Plugin-System
+ */
+type ExportCommandName = 'chtml' | 'cpdf' | 'csvg'
+
+/**
+ * Toast notification severity used by {@link CadViewerApp.showMessage}.
+ */
+type MessageType = 'success' | 'error' | 'info'
+
+/**
+ * Application shell that wires the example HTML UI to `AcApDocManager`.
+ *
+ * Responsibilities:
+ * - Lazy-initialize the CAD viewer on first user action (open file or new drawing)
+ * - Register demo commands and lazy export plugins (HTML / PDF / SVG)
+ * - Handle local DXF/DWG file open, sample drawing creation, and export toolbar actions
+ * - Reflect document state in the DOM (toolbar position, export button visibility)
+ *
+ * The viewer is not created at construction time; call {@link CadViewerApp.initialize}
+ * indirectly via file open or **New** so the initial page load stays lightweight.
+ *
+ * @example
+ * ```typescript
+ * // Bootstrapped at the bottom of this module when the DOM is ready
+ * new CadViewerApp()
+ * ```
+ */
 class CadViewerApp {
+  /**
+   * Host element passed to `AcApDocManager.createInstance` as the WebGL/view canvas parent.
+   * Corresponds to `#cad-container` in `index.html`.
+   */
   private container: HTMLDivElement
+
+  /**
+   * Hidden `<input type="file">` used by the **Open** FAB to pick local `.dxf` / `.dwg` files.
+   * Corresponds to `#fileInputElement`.
+   */
   private fileInput: HTMLInputElement
+
+  /**
+   * Wrapper around the **Open** FAB and label (`#openButtonContainer`).
+   * Hidden while a file is loading; see `loading-file` on `#fileInputContainer`.
+   */
+  private openButtonContainer: HTMLElement
+
+  /**
+   * Wrapper around the **New** FAB and label (`#newButtonContainer`).
+   * Hidden during file load and permanently after a successful open or new drawing.
+   */
+  private newButtonContainer: HTMLElement
+
+  /**
+   * **New** button that populates the current document with {@link DocCreator} sample geometry.
+   * Hidden after the first new drawing or file open via {@link CadViewerApp.hideNewButton}.
+   */
   private newDrawingButton: HTMLButtonElement
+
+  /**
+   * Toolbar control that runs the `chtml` command (lazy {@link registerLazyHtmlPlugin}).
+   * Visible only after a file is opened successfully; see `show-export` in `index.html`.
+   */
+  private exportHtmlButton: HTMLButtonElement
+
+  /**
+   * Toolbar control that runs the `cpdf` command (lazy {@link registerLazyPdfPlugin}).
+   */
+  private exportPdfButton: HTMLButtonElement
+
+  /**
+   * Toolbar control that runs the `csvg` command (lazy {@link registerLazySvgPlugin}).
+   */
+  private exportSvgButton: HTMLButtonElement
+
+  /**
+   * Whether {@link AcApDocManager.createInstance} has completed for this page session.
+   * Stays false until the user opens a file or clicks **New**.
+   */
   private isInitialized: boolean = false
 
+  /**
+   * Whether a DXF/DWG file was opened successfully in this session.
+   *
+   * When true, export commands are allowed and the export toolbar is shown.
+   * Remains false if the user only created a drawing via **New** (export UI stays hidden).
+   */
+  private hasLoadedDocument: boolean = false
+
+  /**
+   * Binds DOM references from `index.html` and registers UI event listeners.
+   *
+   * Does not initialize the CAD viewer; initialization is deferred until
+   * {@link CadViewerApp.loadFile} or the **New** button handler runs.
+   */
   constructor() {
-    // Get DOM elements
     this.container = document.getElementById('cad-container') as HTMLDivElement
     this.fileInput = document.getElementById('fileInputElement') as HTMLInputElement
+    this.openButtonContainer = document.getElementById(
+      'openButtonContainer'
+    ) as HTMLElement
+    this.newButtonContainer = document.getElementById(
+      'newButtonContainer'
+    ) as HTMLElement
     this.newDrawingButton = document.getElementById('newDrawingButton') as HTMLButtonElement
+    this.exportHtmlButton = document.getElementById(
+      'exportHtmlButton'
+    ) as HTMLButtonElement
+    this.exportPdfButton = document.getElementById(
+      'exportPdfButton'
+    ) as HTMLButtonElement
+    this.exportSvgButton = document.getElementById(
+      'exportSvgButton'
+    ) as HTMLButtonElement
 
     this.setupFileHandling()
     this.setupNewDrawingHandling()
+    this.setupExportHandling()
   }
 
-  private initialize() {
+  /**
+   * Creates the singleton `AcApDocManager` and registers commands, plugins, and listeners.
+   *
+   * Configuration highlights:
+   * - `webworkerFileUrls` — parser and MTEXT worker scripts copied to `dist/assets/`
+   * - `htmlViewerRuntimeUrl` — runtime bundle required for offline HTML export (`chtml`)
+   * - `baseUrl` — optional CDN root for built-in resources (demo override)
+   *
+   * Idempotent: subsequent calls are no-ops once {@link CadViewerApp.isInitialized} is true.
+   *
+   * @remarks On failure, logs to the console and shows an error toast via {@link CadViewerApp.showMessage}.
+   */
+  private initialize(): void {
     if (!this.isInitialized) {
       try {
-        // Initialize the document manager with the canvas and baseUrl.
-        // Actually 'baseUrl' here isn't required. Override default 'baseUrl'
-        // value is just for demostration.
         AcApDocManager.createInstance({
           container: this.container,
           autoResize: true,
@@ -43,6 +161,13 @@ class CadViewerApp {
         initializeLocale()
         this.registerCommands()
         this.registerLazyPlugins()
+
+        AcApDocManager.instance.events.documentActivated.addEventListener(
+          args => {
+            document.title = args.doc.docTitle
+          }
+        )
+
         this.isInitialized = true
       } catch (error) {
         console.error('Failed to initialize CAD viewer:', error)
@@ -51,7 +176,14 @@ class CadViewerApp {
     }
   }
 
-  private registerCommands() {
+  /**
+   * Registers example custom commands on the system command group.
+   *
+   * Currently adds `ellipsedemo` ({@link AcApEllipseCmd}) for interactive ellipse creation.
+   *
+   * @remarks Must run after {@link CadViewerApp.initialize} so `commandManager` exists.
+   */
+  private registerCommands(): void {
     const register = AcApDocManager.instance.commandManager
     register.addCommand(
       AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
@@ -62,43 +194,138 @@ class CadViewerApp {
   }
 
   /**
-   * Registers lazy plugins that load on first use of their trigger commands.
+   * Registers lazy export plugins on `AcApDocManager.instance.pluginManager`.
    *
-   * Currently registers the PDF plugin (`cpdf`, `ipdf`), the HTML export
-   * plugin (`chtml`), and the SVG export plugin (`csvg`), which are fetched
-   * only when one of those commands runs.
-   * Safe to call multiple times; registration runs once per application lifetime.
+   * Plugin code is not downloaded until the user runs a trigger command:
+   *
+   * | Package | Trigger commands |
+   * |---------|------------------|
+   * | `@mlightcad/cad-html-plugin` | `chtml` |
+   * | `@mlightcad/cad-pdf-plugin` | `cpdf`, `ipdf` |
+   * | `@mlightcad/cad-svg-plugin` | `csvg` |
+   *
+   * Safe to call only once per application lifetime (guarded by {@link CadViewerApp.initialize}).
+   *
+   * @see https://github.com/mlightcad/cad-viewer/wiki/Plugin-System
    */
-  private registerLazyPlugins() {
+  private registerLazyPlugins(): void {
     const pluginManager = AcApDocManager.instance.pluginManager
     registerLazyHtmlPlugin(pluginManager)
     registerLazyPdfPlugin(pluginManager)
     registerLazySvgPlugin(pluginManager)
   }
 
-  private setupFileHandling() {
-    // File input change event
+  /**
+   * Attaches a `change` listener to the hidden file input for local DXF/DWG open.
+   *
+   * Clears the input value after each selection so the same file can be chosen again.
+   */
+  private setupFileHandling(): void {
     this.fileInput.addEventListener('change', event => {
       const file = (event.target as HTMLInputElement).files?.[0]
       if (file) {
-        this.loadFile(file)
+        void this.loadFile(file)
       }
       this.fileInput.value = ''
     })
   }
 
-  private hideNewButton() {
-    // Hide the new drawing button after creating the drawing
-    this.newDrawingButton.style.display = 'none'
-    // Also hide the associated label
-    const newButtonLabel = this.newDrawingButton.parentElement?.querySelector('.file-fab-label')
-    if (newButtonLabel) {
-      (newButtonLabel as HTMLElement).style.display = 'none'
-    }
+  /**
+   * Hides **Open** and **New** while a DXF/DWG file is being read and opened.
+   *
+   * Toggles the `loading-file` class on `#fileInputContainer` (see `index.html` CSS).
+   */
+  private setFileLoadingUi(loading: boolean): void {
+    const fileInputContainer = document.getElementById('fileInputContainer')
+    fileInputContainer?.classList.toggle('loading-file', loading)
   }
 
-  private setupNewDrawingHandling() {
-    // New drawing button click event
+  /**
+   * Hides the **New** entry control after the user has started a session.
+   *
+   * Called after a successful file open or after creating the sample drawing.
+   */
+  private hideNewButton(): void {
+    this.newButtonContainer.style.display = 'none'
+  }
+
+  /**
+   * Restores **Open** and **New** on the home screen after a failed file open.
+   */
+  private restoreEntryButtons(): void {
+    this.openButtonContainer.style.display = ''
+    this.newButtonContainer.style.display = ''
+  }
+
+  /**
+   * Wires click handlers on the HTML / PDF / SVG export toolbar buttons.
+   *
+   * Each handler delegates to {@link CadViewerApp.runExportCommand} with the
+   * matching plugin trigger command name.
+   */
+  private setupExportHandling(): void {
+    this.exportHtmlButton.addEventListener('click', () => {
+      this.runExportCommand('chtml')
+    })
+    this.exportPdfButton.addEventListener('click', () => {
+      this.runExportCommand('cpdf')
+    })
+    this.exportSvgButton.addEventListener('click', () => {
+      this.runExportCommand('csvg')
+    })
+  }
+
+  /**
+   * Executes an export plugin command if the viewer and a opened file are ready.
+   *
+   * `sendStringToExecute` loads the matching lazy plugin on first use when needed.
+   *
+   * @param command - Plugin trigger: `chtml`, `cpdf`, or `csvg`
+   */
+  private runExportCommand(command: ExportCommandName): void {
+    if (!this.hasLoadedDocument || !this.isInitialized) {
+      return
+    }
+    AcApDocManager.instance.sendStringToExecute(command)
+  }
+
+  /**
+   * Updates UI state after a local DXF/DWG file is opened successfully.
+   *
+   * - Sets {@link CadViewerApp.hasLoadedDocument} to true
+   * - Adds `loaded` and `show-export` classes on `#fileInputContainer` (toolbar layout + export buttons)
+   * - Enables export FABs via {@link CadViewerApp.updateExportButtonsState}
+   */
+  private onFileOpened(): void {
+    this.hasLoadedDocument = true
+    const fileInputContainer = document.getElementById('fileInputContainer')
+    if (fileInputContainer) {
+      fileInputContainer.classList.add('loaded', 'show-export')
+    }
+    this.updateExportButtonsState()
+  }
+
+  /**
+   * Syncs the `disabled` attribute on export buttons with viewer and document readiness.
+   *
+   * Export actions require both {@link CadViewerApp.isInitialized} and
+   * {@link CadViewerApp.hasLoadedDocument}.
+   */
+  private updateExportButtonsState(): void {
+    const enabled = this.hasLoadedDocument && this.isInitialized
+    this.exportHtmlButton.disabled = !enabled
+    this.exportPdfButton.disabled = !enabled
+    this.exportSvgButton.disabled = !enabled
+  }
+
+  /**
+   * Handles **New** — fills the active document with {@link DocCreator.createExampleDoc2}
+   * and fits the view.
+   *
+   * Does not show export buttons (no `show-export` class); only file open does.
+   * Moves the FAB toolbar to the corner via the `loaded` class on `#fileInputContainer`.
+   */
+  private setupNewDrawingHandling(): void {
     this.newDrawingButton.addEventListener('click', () => {
       this.initialize()
       const docManager = AcApDocManager.instance
@@ -108,7 +335,6 @@ class CadViewerApp {
       }
       const doc = docManager.curDocument
       if (doc) {
-        // Add loaded class to move file input container to top-left
         const fileInputContainer = document.getElementById('fileInputContainer')
         if (fileInputContainer) {
           fileInputContainer.classList.add('loaded')
@@ -123,36 +349,38 @@ class CadViewerApp {
     })
   }
 
-  private async loadFile(file: File) {
+  /**
+   * Reads a local file, validates extension, and opens it in the viewer.
+   *
+   * Flow:
+   * 1. {@link CadViewerApp.initialize}
+   * 2. Reject non-`.dxf` / non-`.dwg` names with an error toast
+   * 3. Hide **Open** / **New** via {@link CadViewerApp.setFileLoadingUi} until loading finishes
+   * 4. {@link CadViewerApp.readFile} → `openDocument` with read-only options
+   * 5. On success, {@link CadViewerApp.onFileOpened} and a success toast; on failure, {@link CadViewerApp.restoreEntryButtons}
+   *
+   * @param file - User-selected file from the file input
+   */
+  private async loadFile(file: File): Promise<void> {
     this.initialize()
 
-    // Validate file type
     const fileName = file.name.toLowerCase()
     if (!fileName.endsWith('.dxf') && !fileName.endsWith('.dwg')) {
       this.showMessage('Please select a DXF or DWG file', 'error')
       return
     }
 
-    this.hideNewButton()
     this.clearMessages()
+    this.setFileLoadingUi(true)
 
     try {
-      // Read the file content
       const fileContent = await this.readFile(file)
 
-      // Add loaded class to move file input container to top-left
-      const fileInputContainer = document.getElementById('fileInputContainer')
-      if (fileInputContainer) {
-        fileInputContainer.classList.add('loaded')
-      }
-
-      // Set database options
       const options: AcDbOpenDatabaseOptions = {
         minimumChunkSize: 1000,
         readOnly: true
       }
 
-      // Open the document
       const success = await AcApDocManager.instance.openDocument(
         file.name,
         fileContent,
@@ -160,16 +388,29 @@ class CadViewerApp {
       )
 
       if (success) {
+        this.hideNewButton()
+        this.onFileOpened()
         this.showMessage(`Successfully loaded: ${file.name}`, 'success')
       } else {
+        this.restoreEntryButtons()
         this.showMessage(`Failed to load: ${file.name}`, 'error')
       }
     } catch (error) {
       console.error('Error loading file:', error)
+      this.restoreEntryButtons()
       this.showMessage(`Error loading file: ${error}`, 'error')
+    } finally {
+      this.setFileLoadingUi(false)
     }
   }
 
+  /**
+   * Reads a `File` as raw binary via `FileReader.readAsArrayBuffer`.
+   *
+   * @param file - Browser `File` object from the file picker
+   * @returns Promise that resolves to the file contents as `ArrayBuffer`
+   * @throws Rejects with the `FileReader` error if reading fails
+   */
   private readFile(file: File): Promise<ArrayBuffer> {
     return new Promise((resolve, reject) => {
       const reader = new FileReader()
@@ -179,14 +420,18 @@ class CadViewerApp {
     })
   }
 
-  private showMessage(
-    message: string,
-    type: 'success' | 'error' | 'info' = 'info'
-  ) {
-    // Remove old persistent messages
+  /**
+   * Shows a short-lived centered toast at the top of the viewport.
+   *
+   * Replaces any existing `.popup-message` elements before creating a new one.
+   * Fades out after ~1s and removes the node from the DOM.
+   *
+   * @param message - Text shown to the user
+   * @param type - Controls background and border colors (`success`, `error`, or `info`)
+   */
+  private showMessage(message: string, type: MessageType = 'info'): void {
     this.clearMessages()
 
-    // Create popup message element
     const popup = document.createElement('div')
     popup.className = `popup-message ${type}`
     popup.textContent = message
@@ -227,13 +472,20 @@ class CadViewerApp {
     }, 1000)
   }
 
-  private clearMessages() {
-    // Remove all popup messages
+  /**
+   * Removes all in-flight toast elements (class `popup-message`) from `document.body`.
+   */
+  private clearMessages(): void {
     document.querySelectorAll('.popup-message').forEach(el => el.remove())
   }
 }
 
-// Also initialize immediately if DOM is already loaded
+/**
+ * Starts the example application once the DOM is ready.
+ *
+ * If the script runs after `DOMContentLoaded`, constructs {@link CadViewerApp} immediately;
+ * otherwise waits for that event.
+ */
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', () => {
     new CadViewerApp()

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig(() => {
             dest: 'assets'
           },
           {
-            src: './node_modules/@mlightcad/cad-simple-viewer/dist/viewer-runtime.iife.js',
+            src: './node_modules/@mlightcad/cad-html-plugin/dist/viewer-runtime.iife.js',
             dest: 'assets'
           }
         ]


### PR DESCRIPTION
## Summary

- Upgrade to `@mlightcad/cad-simple-viewer` v1.5.3 and register lazy HTML, PDF, and SVG export plugins from `@mlightcad/cad-html-plugin`, `@mlightcad/cad-pdf-plugin`, and `@mlightcad/cad-svg-plugin`.
- Add export toolbar (HTML / PDF / SVG) after a DXF/DWG file is opened successfully; hide export buttons on the home screen.
- Hide Open and New controls while a file is loading; restore them if open fails.
- Copy `viewer-runtime.iife.js` from `cad-html-plugin` for offline HTML export.
- Rewrite README with plugin integration docs and switch the build script to `tsc`.

## Test plan

- [ ] `pnpm install && pnpm build` succeeds
- [ ] `pnpm dev` — home page shows only Open and New
- [ ] Open a `.dxf` or `.dwg` — Open/New hide during load; export buttons appear after success
- [ ] Export HTML, PDF, and SVG (first run may load plugin chunks)
- [ ] **New** drawing still works; export buttons stay hidden until a file is opened
- [ ] Failed file open restores Open and New on the home screen