### PR TITLE
feat: defer viewer bundle load and preload after first paint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,13 +1,14 @@
-import {
+import type {
   AcApDocManager,
+  AcApOpenDatabaseOptions,
   AcApOpenViewMode,
-  AcEdCommandStack,
-  AcEdOpenMode,
-  applyUiTheme,
-  type AcApOpenDatabaseOptions
+  AcEdOpenMode
 } from '@mlightcad/cad-simple-viewer'
-import { AcApEllipseCmd } from './ellipseCmd'
-import { initializeLocale } from './i8n'
+import {
+  loadCadSimpleViewer,
+  preloadViewerAppModules,
+  scheduleViewerPreload
+} from './viewerLoader'
 import { WEBWORKER_FILE_URLS } from './workerConfig'
 
 /**
@@ -51,13 +52,14 @@ export interface CadViewerAppOptions {
  * Application shell that wires the example HTML UI to `AcApDocManager`.
  *
  * Responsibilities:
- * - Lazy-initialize the CAD viewer on first file open
+ * - Keep the homepage free of a static `@mlightcad/cad-simple-viewer` import
+ * - Preload viewer JS after first paint, then create the viewer on first file open
  * - Optionally register demo commands, lazy export plugins, and the simple UI plugin
  * - Handle local DXF/DWG file open with configurable open options
  * - Reflect document state in the DOM (upload screen vs viewer)
  *
- * The viewer is not created at construction time; call {@link CadViewerApp.initialize}
- * indirectly via file open so the initial page load stays lightweight.
+ * The viewer package and `AcApDocManager.createInstance` are deferred until needed;
+ * {@link scheduleViewerPreload} warms the module cache in the background.
  */
 export class CadViewerApp {
   /**
@@ -126,10 +128,17 @@ export class CadViewerApp {
   private readonly enablePlugins: boolean
 
   /**
+   * Cached `AcApDocManager` class after the viewer module has been loaded.
+   * Set during {@link CadViewerApp.initialize}.
+   */
+  private DocManager: typeof AcApDocManager | null = null
+
+  /**
    * Binds DOM references from the page HTML and registers UI event listeners.
    *
-   * Does not initialize the CAD viewer; initialization is deferred until
-   * {@link CadViewerApp.loadFile} runs.
+   * Does not load `@mlightcad/cad-simple-viewer` or create the CAD viewer;
+   * schedules a background preload and initializes on first file open /
+   * new drawing.
    *
    * @param options - App options; set `enablePlugins: false` for a bare viewer
    */
@@ -150,6 +159,7 @@ export class CadViewerApp {
     this.setupFileHandling()
     this.setupNewDrawingHandling()
     this.setupReopenHandling()
+    scheduleViewerPreload(this.enablePlugins)
   }
 
   /**
@@ -211,6 +221,9 @@ export class CadViewerApp {
   /**
    * Creates the singleton `AcApDocManager` and registers commands, plugins, and listeners.
    *
+   * Dynamically imports `@mlightcad/cad-simple-viewer` (reusing any background preload)
+   * before calling `createInstance`.
+   *
    * Configuration highlights:
    * - `webworkerFileUrls` — DWG parser and MTEXT worker scripts copied to `dist/assets/`
    * - `checkWorkersOnInit` — probe worker URLs after registration (see {@link WEBWORKER_FILE_URLS})
@@ -236,6 +249,12 @@ export class CadViewerApp {
     }
 
     try {
+      // Prefer the shared preload promise so first open awaits in-flight work
+      await preloadViewerAppModules(this.enablePlugins)
+      const { AcApDocManager, AcEdCommandStack, applyUiTheme } =
+        await loadCadSimpleViewer()
+      this.DocManager = AcApDocManager
+
       applyUiTheme('dark', this.viewerPane)
 
       const workersReachable = await AcApDocManager.checkWebworkerReadiness(
@@ -276,8 +295,9 @@ export class CadViewerApp {
         this.setUploadLoading(true)
       })
 
+      const { initializeLocale } = await import('./i8n')
       initializeLocale()
-      this.registerCommands()
+      await this.registerCommands(AcEdCommandStack)
 
       if (this.enablePlugins) {
         // Dynamic import keeps plugin `/register` stubs out of the bare-viewer entry
@@ -307,16 +327,30 @@ export class CadViewerApp {
    *
    * Currently adds `ellipsedemo` ({@link AcApEllipseCmd}) for interactive ellipse creation.
    *
+   * @param AcEdCommandStack - Command stack class from the loaded viewer module
    * @remarks Must run after {@link CadViewerApp.initialize} so `commandManager` exists.
    */
-  private registerCommands(): void {
-    const register = AcApDocManager.instance.commandManager
+  private async registerCommands(
+    AcEdCommandStack: (typeof import('@mlightcad/cad-simple-viewer'))['AcEdCommandStack']
+  ): Promise<void> {
+    const { AcApEllipseCmd } = await import('./ellipseCmd')
+    const register = this.requireDocManager().instance.commandManager
     register.addCommand(
       AcEdCommandStack.SYSTEMT_COMMAND_GROUP_NAME,
       'ellipsedemo',
       'ellipsedemo',
       new AcApEllipseCmd()
     )
+  }
+
+  /**
+   * Returns the cached `AcApDocManager` class after successful initialization.
+   */
+  private requireDocManager(): typeof AcApDocManager {
+    if (!this.DocManager) {
+      throw new Error('CAD viewer is not initialized')
+    }
+    return this.DocManager
   }
 
   /**
@@ -380,7 +414,7 @@ export class CadViewerApp {
       if (!this.isInitialized) {
         return
       }
-      AcApDocManager.instance.sendStringToExecute('open')
+      this.requireDocManager().instance.sendStringToExecute('open')
     })
   }
 
@@ -417,7 +451,7 @@ export class CadViewerApp {
           : {})
       }
 
-      const success = await AcApDocManager.instance.newDocument(options)
+      const success = await this.requireDocManager().instance.newDocument(options)
 
       if (success) {
         this.hideUploadScreen()
@@ -509,7 +543,7 @@ export class CadViewerApp {
     this.clearMessages()
 
     try {
-      const docManager = AcApDocManager.instance
+      const docManager = this.requireDocManager().instance
       if (!(await docManager.areWorkersReady())) {
         this.showMessage(
           'CAD worker scripts are not reachable. Check deployment of assets/*-worker.js.',

--- a/src/viewerLoader.ts
+++ b/src/viewerLoader.ts
@@ -1,0 +1,76 @@
+/**
+ * Lazy loader for `@mlightcad/cad-simple-viewer` and app modules that depend on it.
+ *
+ * Keeps the upload-screen entry free of a static viewer import so the homepage
+ * JS stays small. Call {@link preloadViewerAppModules} after first paint to warm
+ * the module cache before the user opens a file.
+ */
+
+type CadSimpleViewerModule = typeof import('@mlightcad/cad-simple-viewer')
+
+let viewerModulePromise: Promise<CadSimpleViewerModule> | null = null
+let appModulesPromise: Promise<void> | null = null
+
+/**
+ * Dynamically imports `@mlightcad/cad-simple-viewer` (and its chunked peers).
+ * Subsequent calls reuse the same promise / module cache.
+ */
+export function loadCadSimpleViewer(): Promise<CadSimpleViewerModule> {
+  if (!viewerModulePromise) {
+    viewerModulePromise = import('@mlightcad/cad-simple-viewer').catch(error => {
+      viewerModulePromise = null
+      throw error
+    })
+  }
+  return viewerModulePromise
+}
+
+/**
+ * Preloads the viewer package plus local modules needed on first open
+ * (`i18n`, ellipse demo command, and optionally plugin registration).
+ *
+ * Safe to call multiple times; work is shared via a single promise.
+ * Failed attempts clear the cached promise so a later open can retry.
+ *
+ * @param enablePlugins - When `true`, also warms `./register`
+ */
+export function preloadViewerAppModules(enablePlugins: boolean): Promise<void> {
+  if (!appModulesPromise) {
+    appModulesPromise = (async () => {
+      await loadCadSimpleViewer()
+      const tasks: Promise<unknown>[] = [import('./i8n'), import('./ellipseCmd')]
+      if (enablePlugins) {
+        tasks.push(import('./register'))
+      }
+      await Promise.all(tasks)
+    })().catch(error => {
+      appModulesPromise = null
+      throw error
+    })
+  }
+  return appModulesPromise
+}
+
+/**
+ * Schedules {@link preloadViewerAppModules} after the upload UI has painted,
+ * using idle time so it does not compete with first paint.
+ *
+ * @param enablePlugins - Forwarded to {@link preloadViewerAppModules}
+ */
+export function scheduleViewerPreload(enablePlugins: boolean): void {
+  const run = () => {
+    void preloadViewerAppModules(enablePlugins)
+  }
+
+  const afterPaint = () => {
+    if (typeof requestIdleCallback === 'function') {
+      requestIdleCallback(() => run(), { timeout: 2500 })
+    } else {
+      setTimeout(run, 50)
+    }
+  }
+
+  requestAnimationFrame(() => {
+    requestAnimationFrame(afterPaint)
+  })
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,9 +12,19 @@ import { viteStaticCopy } from 'vite-plugin-static-copy'
  * (tight class hierarchy). Keep `mtext-*` / `shx-parser` with `three-renderer`
  * so they are not absorbed into `cad-simple-viewer` and create a circular chunk
  * edge. `three` includes `three/examples/jsm/*`.
+ *
+ * Keep Vite's `__vitePreload` helper out of the viewer chunk. Otherwise Rollup
+ * places it inside `cad-simple-viewer`, and the tiny app entry must statically
+ * import that whole chunk (plus three / data-model) just to call dynamic import.
  */
 function viewerManualChunk(id: string): string | undefined {
   const path = id.replace(/\\/g, '/')
+  if (
+    path.includes('vite/preload-helper') ||
+    path.includes('vite/modulepreload-polyfill')
+  ) {
+    return 'vite-preload'
+  }
   if (
     path.includes('/node_modules/three/') ||
     path.includes('/node_modules/.pnpm/three@')


### PR DESCRIPTION
## Summary
- Defer `@mlightcad/cad-simple-viewer` to a dynamic import via `viewerLoader`, so the upload homepage entry stays free of a static viewer dependency
- Schedule idle-time preload after first paint; clear cached promises on failure so a later open can retry
- Keep Vite `__vitePreload` / modulepreload helpers in a separate `vite-preload` chunk so the entry does not pull in the full viewer graph

## Test plan
- [ ] Load the default demo: confirm upload UI paints before viewer chunks download (Network tab)
- [ ] Open a DXF/DWG shortly after load (preload should already be warm)
- [ ] Open a file immediately on first paint (initialize awaits in-flight preload)
- [ ] Load `mainNoPlugin` / no-plugin page and confirm plugins are not fetched
- [ ] Confirm built chunks: entry does not statically import `cad-simple-viewer-*.js`; `vite-preload` chunk exists