### PR TITLE
feat: opt into LibreDWG DWG parsing and upgrade to v1.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ auto-imports.d.ts
 /.idea
 .project
 .classpath
+.chrome-*/
 .c9/
 *.launch
 .settings/

--- a/README.md
+++ b/README.md
@@ -30,17 +30,23 @@ pnpm build    # Typecheck + production build
 pnpm preview  # Serve dist/
 ```
 
-The build copies DWG/MTEXT workers into `dist/assets/`. If `@mlightcad/cad-html-plugin` is installed, it also copies `viewer-runtime.iife.js` (HTML export only — see [HTML plugin and viewer-runtime](#html-plugin-and-viewer-runtimeiifejs-are-optional)).
+The build copies the MTEXT worker from `@mlightcad/cad-simple-viewer` and the LibreDWG worker (+ wasm) from `@mlightcad/libredwg-converter` into `dist/assets/` (wasm must sit next to the LibreDWG worker for `import.meta.url`). If `@mlightcad/cad-html-plugin` is installed, it also copies `viewer-runtime.iife.js` (HTML export only — see [HTML plugin and viewer-runtime](#html-plugin-and-viewer-runtimeiifejs-are-optional)).
 
 ## Web Worker readiness
 
-DWG parsing and MTEXT rendering run in separate worker scripts. DXF is parsed by the built-in converter in `@mlightcad/data-model` (no separate worker). Host apps must deploy the DWG/MTEXT worker files and set `webworkerFileUrls` in `AcApDocManager.createInstance()`. Before opening a drawing, verify the workers are reachable — do **not** probe them with a plain GET (the LibreDWG worker alone is ~12 MB).
+MTEXT rendering runs in a worker shipped with `@mlightcad/cad-simple-viewer`. DXF is parsed by the built-in converter in `@mlightcad/data-model` (no separate worker). **DWG support is opt-in** because LibreDWG is GPL: this example depends on `@mlightcad/libredwg-converter`, deploys its worker (+ wasm), and registers the converter via [`src/registerLibreDwg.ts`](./src/registerLibreDwg.ts) before `createInstance`. Host apps that skip DWG can omit that package and `webworkerFileUrls.dwgParser`.
+
+Before opening a drawing, verify the workers are reachable — do **not** probe them with a plain full GET (the LibreDWG **wasm** next to the worker is ~10 MB).
 
 This example centralizes URLs in [`src/workerConfig.ts`](./src/workerConfig.ts) and demonstrates the readiness APIs from [`@mlightcad/cad-simple-viewer`](https://github.com/mlightcad/cad-viewer/tree/main/packages/cad-simple-viewer) in [`src/app.ts`](./src/app.ts):
 
 ```typescript
 import { AcApDocManager } from '@mlightcad/cad-simple-viewer'
+import { registerLibreDwgConverter } from './registerLibreDwg'
 import { WEBWORKER_FILE_URLS } from './workerConfig'
+
+// Deploy worker + wasm side-by-side under ./assets/ (see vite.config.ts)
+registerLibreDwgConverter(WEBWORKER_FILE_URLS.dwgParser)
 
 // Option 1: check before createInstance (HEAD + ranged GET fallback; caches successes)
 const ready = await AcApDocManager.checkWebworkerReadiness(WEBWORKER_FILE_URLS)
@@ -108,10 +114,10 @@ bootCadViewerApp({ enablePlugins: false })
 Equivalent manual setup after `AcApDocManager.createInstance()`:
 
 ```typescript
-import { AcApDocManager, applyUiTheme } from '@mlightcad/cad-simple-viewer'
+import { AcApDocManager, acedApplyUiTheme } from '@mlightcad/cad-simple-viewer'
 import { WEBWORKER_FILE_URLS } from './workerConfig'
 
-applyUiTheme('dark', host)
+acedApplyUiTheme('dark', host)
 
 AcApDocManager.createInstance({
   container: document.getElementById('cad-container')!,
@@ -176,7 +182,7 @@ Then open either demo page and load a DXF/DWG — viewing still works. On the **
 | Format | Notes |
 |--------|--------|
 | **DXF** | Built-in converter in `@mlightcad/data-model` (no separate worker) |
-| **DWG** | LibreDWG WebAssembly via `libredwg-parser-worker.js` |
+| **DWG** | Optional `@mlightcad/libredwg-converter` (GPL) — registered by this example |
 
 ## Simple UI plugin
 
@@ -184,11 +190,11 @@ Toolbar chrome comes from `@mlightcad/cad-simple-ui-plugin`, not custom HTML but
 
 ```typescript
 import { registerSimpleUiPlugin } from '@mlightcad/cad-simple-ui-plugin/register'
-import { AcApDocManager, applyUiTheme } from '@mlightcad/cad-simple-viewer'
+import { AcApDocManager, acedApplyUiTheme } from '@mlightcad/cad-simple-viewer'
 
 const host = document.getElementById('viewerPane')!
 
-applyUiTheme('dark', host)
+acedApplyUiTheme('dark', host)
 
 AcApDocManager.createInstance({
   container: document.getElementById('cad-container')!,
@@ -346,7 +352,7 @@ Shared settings (both approaches):
 
 - **`base: './'`** — relative asset URLs for static hosting (e.g. GitHub Pages).
 - **`build.modulePreload: false`** — do not inject `<link rel="modulepreload">` for lazy chunks; plugin bundles load only when a trigger command runs.
-- **`vite-plugin-static-copy`** — copy DWG/MTEXT workers into `dist/assets/` (required for DWG/MTEXT). Copy `viewer-runtime.iife.js` **only if** `@mlightcad/cad-html-plugin` is installed (optional; HTML export only).
+- **`vite-plugin-static-copy`** — copy the MTEXT worker from `cad-simple-viewer` and the LibreDWG worker (+ wasm) from `@mlightcad/libredwg-converter` into `dist/assets/` (required for MTEXT / DWG; wasm must be next to the LibreDWG worker). Use `rename: { stripBase: true }` with `vite-plugin-static-copy` ≥ 4. Copy `viewer-runtime.iife.js` **only if** `@mlightcad/cad-html-plugin` is installed (optional; HTML export only).
 - **`pnpm analyze`** — `vite build --mode analyze` writes `stats.html` for bundle inspection.
 
 ### Approach A — Viewer stack in separate chunks (default in this repo)
@@ -373,6 +379,12 @@ import { viteStaticCopy } from 'vite-plugin-static-copy'
 
 function viewerManualChunk(id: string): string | undefined {
   const path = id.replace(/\\/g, '/')
+  if (
+    path.includes('vite/preload-helper') ||
+    path.includes('vite/modulepreload-polyfill')
+  ) {
+    return 'vite-preload'
+  }
   if (
     path.includes('/node_modules/three/') ||
     path.includes('/node_modules/.pnpm/three@')
@@ -421,12 +433,29 @@ export default defineConfig(({ mode }) => ({
     viteStaticCopy({
       targets: [
         {
-          src: './node_modules/@mlightcad/cad-simple-viewer/dist/*-worker.js',
-          dest: 'assets'
+          src: './node_modules/@mlightcad/cad-simple-viewer/dist/mtext-renderer-worker.js',
+          dest: 'assets',
+          rename: { stripBase: true }
+        },
+        {
+          src: './node_modules/@mlightcad/libredwg-converter/dist/libredwg-parser-worker.js',
+          dest: 'assets',
+          rename: { stripBase: true }
+        },
+        {
+          src: './node_modules/@mlightcad/libredwg-converter/dist/libredwg-web.wasm',
+          dest: 'assets',
+          rename: { stripBase: true }
         },
         // Optional — omit entirely if you do not use HTML export
         ...(existsSync(resolve(__dirname, viewerRuntimeSrc))
-          ? [{ src: viewerRuntimeSrc, dest: 'assets' }]
+          ? [
+              {
+                src: viewerRuntimeSrc,
+                dest: 'assets',
+                rename: { stripBase: true }
+              }
+            ]
           : [])
       ]
     }),
@@ -436,7 +465,7 @@ export default defineConfig(({ mode }) => ({
 }))
 ```
 
-The current [`vite.config.ts`](./vite.config.ts) copies `viewer-runtime.iife.js` only when the HTML plugin package is present. Multi-page `input` emits both `index.html` and `no-plugin.html` into `dist/`.
+The current [`vite.config.ts`](./vite.config.ts) copies workers and wasm into `dist/assets/` (with `rename: { stripBase: true }` for `vite-plugin-static-copy` ≥ 4), and copies `viewer-runtime.iife.js` only when the HTML plugin package is present. Multi-page `input` emits both `index.html` and `no-plugin.html` into `dist/`.
 
 ### Approach B — Viewer in the main bundle (simpler)
 
@@ -465,12 +494,24 @@ export default defineConfig(({ mode }) => ({
     viteStaticCopy({
       targets: [
         {
-          src: './node_modules/@mlightcad/cad-simple-viewer/dist/*-worker.js',
-          dest: 'assets'
+          src: './node_modules/@mlightcad/cad-simple-viewer/dist/mtext-renderer-worker.js',
+          dest: 'assets',
+          rename: { stripBase: true }
+        },
+        {
+          src: './node_modules/@mlightcad/libredwg-converter/dist/libredwg-parser-worker.js',
+          dest: 'assets',
+          rename: { stripBase: true }
+        },
+        {
+          src: './node_modules/@mlightcad/libredwg-converter/dist/libredwg-web.wasm',
+          dest: 'assets',
+          rename: { stripBase: true }
         },
         {
           src: './node_modules/@mlightcad/cad-html-plugin/dist/viewer-runtime.iife.js',
-          dest: 'assets'
+          dest: 'assets',
+          rename: { stripBase: true }
         }
       ]
     }),
@@ -510,7 +551,8 @@ HTML export embeds `viewer-runtime.iife.js` from `@mlightcad/cad-html-plugin` (n
 
 When the package is installed, `vite-plugin-static-copy` (see [Vite configuration](#vite-configuration)) copies:
 
-- `./node_modules/@mlightcad/cad-simple-viewer/dist/*-worker.js` → `assets/` (DWG parser, mtext renderer) — always
+- `./node_modules/@mlightcad/cad-simple-viewer/dist/mtext-renderer-worker.js` → `assets/` — always
+- `./node_modules/@mlightcad/libredwg-converter/dist/libredwg-parser-worker.js` (+ `libredwg-web.wasm`) → `assets/` — when opting into DWG (wasm must be beside the worker)
 - `./node_modules/@mlightcad/cad-html-plugin/dist/viewer-runtime.iife.js` → `assets/` — only if the package is present
 
 If you use HTML export and `viewer-runtime.iife.js` is missing or the URL is wrong, export fails when loading the runtime (or the dev server may return `index.html` and you see `Unexpected token '<'`).
@@ -522,17 +564,18 @@ If you use HTML export and `viewer-runtime.iife.js` is missing or the URL is wro
 ```json
 {
   "dependencies": {
-    "@mlightcad/cad-simple-viewer": "^1.5.9",
-    "@mlightcad/cad-simple-ui-plugin": "^1.5.9",
-    "@mlightcad/data-model": "^1.12.2",
-    "@mlightcad/cad-html-plugin": "^1.5.9",
-    "@mlightcad/cad-pdf-plugin": "^1.5.9",
-    "@mlightcad/cad-svg-plugin": "^1.5.9"
+    "@mlightcad/cad-simple-viewer": "1.6.0",
+    "@mlightcad/cad-simple-ui-plugin": "1.6.0",
+    "@mlightcad/data-model": "1.13.0",
+    "@mlightcad/libredwg-converter": "^3.13.0",
+    "@mlightcad/cad-html-plugin": "1.6.0",
+    "@mlightcad/cad-pdf-plugin": "1.6.0",
+    "@mlightcad/cad-svg-plugin": "1.6.0"
   }
 }
 ```
 
-Add `cad-simple-ui-plugin` for toolbar chrome. Add export plugin packages only for the formats you need, and register each one with lazy loaders as shown above. **`@mlightcad/cad-html-plugin` is optional** — required only for offline HTML export (`chtml`), not for viewing drawings (see [HTML plugin and viewer-runtime](#html-plugin-and-viewer-runtimeiifejs-are-optional)).
+Add `cad-simple-ui-plugin` for toolbar chrome. Add `@mlightcad/libredwg-converter` only if you need DWG (GPL). Add export plugin packages only for the formats you need, and register each one with lazy loaders as shown above. **`@mlightcad/cad-html-plugin` is optional** — required only for offline HTML export (`chtml`), not for viewing drawings (see [HTML plugin and viewer-runtime](#html-plugin-and-viewer-runtimeiifejs-are-optional)).
 
 ### HTML container
 
@@ -546,7 +589,7 @@ Add `cad-simple-ui-plugin` for toolbar chrome. Add export plugin packages only f
 </body>
 ```
 
-- `viewerPane` — host for `applyUiTheme`, `busyIndicatorHost`, and the simple UI plugin (`host` option)
+- `viewerPane` — host for `acedApplyUiTheme`, `busyIndicatorHost`, and the simple UI plugin (`host` option)
 - `.viewer-canvas-area` — parent of the canvas; preferred dock mount target (see [Dock panel host layout](#dock-panel-host-layout))
 - `cad-container` — WebGL / view canvas parent passed to `AcApDocManager.createInstance({ container })`
 
@@ -573,7 +616,7 @@ await AcApDocManager.instance.openDocument(file.name, fileContent, options)
 |-------|----------------|
 | Multi-page demos | `index.html` (plugins on) + `no-plugin.html` (plugins off) |
 | Document manager | `AcApDocManager.createInstance({ container, busyIndicatorHost, baseUrl, webworkerFileUrls })` |
-| UI theme | `applyUiTheme('dark', host)` before `createInstance` |
+| UI theme | `acedApplyUiTheme('dark', host)` before `createInstance` |
 | Simple UI | `registerSimpleUiPlugin` via `src/register.ts` — toolbar, dock panel / Layer Manager, export submenu |
 | Skip plugins | `bootCadViewerApp({ enablePlugins: false })` — see [Running without plugins](#running-without-plugins) |
 | HTML runtime URL | `registerLazyHtmlPlugin(pm, { viewerRuntimeUrl })` — not on `createInstance` |
@@ -582,7 +625,7 @@ await AcApDocManager.instance.openDocument(file.name, fileContent, options)
 | Custom commands | `commandManager.addCommand(...)` — see `src/ellipseCmd.ts` |
 | Lazy export plugins | `/register` stubs in `src/register.ts` — HTML, PDF, SVG chunks on first trigger |
 | Export (API) | `sendStringToExecute('chtml' \| 'cpdf' \| 'csvg')` — same commands as toolbar export menu |
-| Workers & assets | `webworkerFileUrls`, static copy in Vite (see [Vite configuration](#vite-configuration)) |
+| Workers & assets | `webworkerFileUrls`, static copy in Vite; LibreDWG via `registerLibreDwg.ts` (see [Vite configuration](#vite-configuration)) |
 | Worker readiness | `checkWebworkerReadiness`, `areWorkersReady`, `checkWorkersOnInit`, `workersReady` event (see [Web Worker readiness](#web-worker-readiness)) |
 
 Lazy initialization: `AcApDocManager` is created on first file open, not at page load.
@@ -597,11 +640,12 @@ Lazy initialization: `AcApDocManager` is created on first file open, not at page
 | `src/app.ts` | `CadViewerApp` + `bootCadViewerApp` — lazy init, worker checks, optional plugins |
 | `src/main.ts` | Entry for with-plugins page (`enablePlugins: true`) |
 | `src/mainNoPlugin.ts` | Entry for bare viewer page (`enablePlugins: false`) |
-| `src/workerConfig.ts` | Shared `webworkerFileUrls` paths for init and readiness probes |
+| `src/workerConfig.ts` | Shared `webworkerFileUrls` paths under `./assets/` |
+| `src/registerLibreDwg.ts` | Host opt-in: registers GPL `@mlightcad/libredwg-converter` for DWG |
 | `src/register.ts` | Plugin registration — lazy export plugins + simple UI (`viewerRuntimeUrl` on HTML plugin) |
 | `src/ellipseCmd.ts` | Custom `ellipsedemo` command |
 | `src/docCreator.ts` | Sample drawing factory helper |
-| `vite.config.ts` | Multi-page inputs, Approach A `manualChunks`, conditional copy of `viewer-runtime.iife.js` |
+| `vite.config.ts` | Multi-page inputs, Approach A `manualChunks`, copy workers/wasm (+ optional `viewer-runtime.iife.js`) to `dist/assets/` |
 
 ## Beyond a viewer
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A vanilla TypeScript **multi-page** demo that shows how to embed [`@mlightcad/ca
 
 ## Prerequisites
 
-- Node.js **≥ 20** and pnpm **≥ 10**
+- Node.js **≥ 22** and pnpm **≥ 10** (`vite-plugin-static-copy` v4)
 
 ## Getting started
 

--- a/package.json
+++ b/package.json
@@ -18,14 +18,15 @@
     "rollup-plugin-visualizer": "^6.0.3",
     "typescript": "^5.5.2",
     "vite": "^6.4.3",
-    "vite-plugin-static-copy": "^3.1.1"
+    "vite-plugin-static-copy": "^4.1.1"
   },
   "dependencies": {
-    "@mlightcad/cad-html-plugin": "1.5.11",
-    "@mlightcad/cad-pdf-plugin": "1.5.11",
-    "@mlightcad/cad-svg-plugin": "1.5.11",
-    "@mlightcad/cad-simple-ui-plugin": "1.5.11",
-    "@mlightcad/cad-simple-viewer": "1.5.11",
-    "@mlightcad/data-model": "1.12.5"
+    "@mlightcad/cad-html-plugin": "1.6.0",
+    "@mlightcad/cad-pdf-plugin": "1.6.0",
+    "@mlightcad/cad-svg-plugin": "1.6.0",
+    "@mlightcad/cad-simple-ui-plugin": "1.6.0",
+    "@mlightcad/cad-simple-viewer": "1.6.0",
+    "@mlightcad/data-model": "1.13.0",
+    "@mlightcad/libredwg-converter": "^3.13.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,23 +9,26 @@ importers:
   .:
     dependencies:
       '@mlightcad/cad-html-plugin':
-        specifier: 1.5.11
-        version: 1.5.11(@mlightcad/cad-simple-viewer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.12.5)(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(three@0.172.0)
+        specifier: 1.6.0
+        version: 1.6.0(@mlightcad/cad-simple-viewer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.13.0)(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(three@0.172.0)
       '@mlightcad/cad-pdf-plugin':
-        specifier: 1.5.11
-        version: 1.5.11(@mlightcad/cad-simple-viewer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/cad-svg-plugin@1.5.11(@mlightcad/cad-simple-viewer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-parser@1.5.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0)))(@mlightcad/data-model@1.12.5)
+        specifier: 1.6.0
+        version: 1.6.0(@mlightcad/cad-simple-viewer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/cad-svg-plugin@1.6.0(@mlightcad/cad-simple-viewer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-parser@1.5.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0)))(@mlightcad/data-model@1.13.0)
       '@mlightcad/cad-simple-ui-plugin':
-        specifier: 1.5.11
-        version: 1.5.11(@mlightcad/cad-simple-viewer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.12.5)
+        specifier: 1.6.0
+        version: 1.6.0(@mlightcad/cad-simple-viewer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.13.0)
       '@mlightcad/cad-simple-viewer':
-        specifier: 1.5.11
-        version: 1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0)
+        specifier: 1.6.0
+        version: 1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0)
       '@mlightcad/cad-svg-plugin':
-        specifier: 1.5.11
-        version: 1.5.11(@mlightcad/cad-simple-viewer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-parser@1.5.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))
+        specifier: 1.6.0
+        version: 1.6.0(@mlightcad/cad-simple-viewer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-parser@1.5.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))
       '@mlightcad/data-model':
-        specifier: 1.12.5
-        version: 1.12.5
+        specifier: 1.13.0
+        version: 1.13.0
+      '@mlightcad/libredwg-converter':
+        specifier: ^3.13.0
+        version: 3.13.0(@mlightcad/data-model@1.13.0)
     devDependencies:
       rollup-plugin-visualizer:
         specifier: ^6.0.3
@@ -37,8 +40,8 @@ importers:
         specifier: ^6.4.3
         version: 6.4.3
       vite-plugin-static-copy:
-        specifier: ^3.1.1
-        version: 3.1.2(vite@6.4.3)
+        specifier: ^4.1.1
+        version: 4.1.1(vite@6.4.3)
 
 packages:
 
@@ -202,60 +205,69 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
-  '@mlightcad/cad-html-plugin@1.5.11':
-    resolution: {integrity: sha512-pnwmEuellm+vZ+ylB2nTiy5bDf36cs3WKHQTCf3jnu4X9U3ziQMVdh//gLW8hUG/f2ECIvw5rRQWVcpNHE/AbQ==}
+  '@mlightcad/cad-html-plugin@1.6.0':
+    resolution: {integrity: sha512-9u5HoiPDp/rv/raP2eFBPpFiIzzj5hdHoY6vNxMwHh8YsX5QdgYkfTKAoPrgvhEP8lZt7y1jmPQBW9Euk+lF4w==}
     peerDependencies:
-      '@mlightcad/cad-simple-viewer': 1.5.11
-      '@mlightcad/data-model': ^1.12.5
-      '@mlightcad/three-renderer': 1.5.11
+      '@mlightcad/cad-simple-viewer': 1.6.0
+      '@mlightcad/data-model': ^1.13.0
+      '@mlightcad/three-renderer': 1.6.0
       three: ^0.172.0
 
-  '@mlightcad/cad-pdf-plugin@1.5.11':
-    resolution: {integrity: sha512-idbtr90sXf01uS9Eewaec6E/QBRvbNtDNpOLFjgUU+S/UuRQa+WNu1mLfbkuVdKTB1II1X3W9RYkKwww3rjvfQ==}
+  '@mlightcad/cad-pdf-plugin@1.6.0':
+    resolution: {integrity: sha512-1uJbPvdG5zyVRG8lCoptpeisNkPYsz+9w10UivmvX9ojCJH5KAOs23OjuLjHHaJsRadMmDuw0aTHWgY7fbv93g==}
     peerDependencies:
-      '@mlightcad/cad-simple-viewer': 1.5.11
-      '@mlightcad/cad-svg-plugin': 1.5.11
-      '@mlightcad/data-model': ^1.12.5
+      '@mlightcad/cad-simple-viewer': 1.6.0
+      '@mlightcad/cad-svg-plugin': 1.6.0
+      '@mlightcad/data-model': ^1.13.0
 
-  '@mlightcad/cad-simple-ui-plugin@1.5.11':
-    resolution: {integrity: sha512-6u2NiBtHBGLrwTruHg7xFQaWw1yuQc06kWel4CmQk1gSiH/s2UqQ+lfA+iqipQZxg3tEQGHH0N0Y5giiOCYegg==}
+  '@mlightcad/cad-simple-ui-plugin@1.6.0':
+    resolution: {integrity: sha512-6t1hmrZicBLjZE9xCDNU8CmbVEqH+QE3qgcBS4SDpkEgpE5XYiL5JL+QoI6cRlj2TyhDGzgNCNowtI6lgVgxKQ==}
     peerDependencies:
-      '@mlightcad/cad-simple-viewer': 1.5.11
-      '@mlightcad/data-model': ^1.12.5
+      '@mlightcad/cad-simple-viewer': 1.6.0
+      '@mlightcad/data-model': ^1.13.0
 
-  '@mlightcad/cad-simple-viewer@1.5.11':
-    resolution: {integrity: sha512-DaRadZlalnX7SdPt0IrthWyR3E1U3uA7oUqCTDdQ6Z7x0N6bHDkI9NdM5VQBe6959ldZX4mkysutvoyBKc7JMA==}
+  '@mlightcad/cad-simple-viewer@1.6.0':
+    resolution: {integrity: sha512-jOMMCtwoHiLIbZU788KLpOBXuAUZaknrtQq6SmSWnVvAty3WaeGApiLsc8V7jTrdyrNoUufrNKS0OBx4hbelyw==}
     peerDependencies:
-      '@mlightcad/data-model': ^1.12.5
+      '@mlightcad/data-model': ^1.13.0
       '@mlightcad/mtext-renderer': ^0.12.4
-      '@mlightcad/three-renderer': 1.5.11
+      '@mlightcad/three-renderer': 1.6.0
       lodash-es: 4.17.21
       three: ^0.172.0
 
-  '@mlightcad/cad-svg-plugin@1.5.11':
-    resolution: {integrity: sha512-dftA9lInL2DxmMyQaBeoNlqyEYxygOYoNlsWCETwMPNWWMOUCR99/vLYGXyhWQcyjfd3TT8faMPwvTkS2Zf0AQ==}
+  '@mlightcad/cad-svg-plugin@1.6.0':
+    resolution: {integrity: sha512-7cy40VBCl/WIckzRDHCTXYLWAXoLzKCxkg1i8eWrY+KmDYngdLeDIG0T9paKwC7Q+fa2fRAsM++vlTbRdvO31A==}
     peerDependencies:
-      '@mlightcad/cad-simple-viewer': 1.5.11
-      '@mlightcad/data-model': ^1.12.5
+      '@mlightcad/cad-simple-viewer': 1.6.0
+      '@mlightcad/data-model': ^1.13.0
       '@mlightcad/mtext-parser': ^1.4.1
       '@mlightcad/mtext-renderer': ^0.12.4
 
-  '@mlightcad/common@1.12.5':
-    resolution: {integrity: sha512-r9xrQ6SzdB4XS3LWCUT6+np55iZg9a6pU6WeQca1X5TbWFnYcHphT94oSkRG3gJhHNDVbe2XSa/4XxW0DFub6Q==}
+  '@mlightcad/common@1.13.0':
+    resolution: {integrity: sha512-m7QnvuhKisSi+xfiMwxxBUlaZHLPsJYcAHiry+CHt4Hb0AAetWZE4wsmxWH7muOeem64YxFVvyAq1J9DNelsZg==}
 
-  '@mlightcad/data-model@1.12.5':
-    resolution: {integrity: sha512-7TUbhARmWqHCHa3Jndb4HnW3wT+3UfmAoDGkN2N031hwMgWZHai/QdaE5qjZ5E1ycCDtDXTByGlBB52J3QJ/jw==}
+  '@mlightcad/data-model@1.13.0':
+    resolution: {integrity: sha512-YTjSTRiUvqXf2UlEfkohL3M5v0nmGK2DcoOjbUKmgLr6H5ETk4emYXqj9JmVjgwuV5zsXeRr/55do9lh5zD33w==}
 
-  '@mlightcad/geometry-engine@3.12.5':
-    resolution: {integrity: sha512-1cQbudkSQAM/XyktC2ni6/+aWpI2DAmF/0Ug1linilEDrVSK75zhbovmNQsc7DRXjubqskUCe26GMxcm0Ly3KQ==}
+  '@mlightcad/geometry-engine@3.13.0':
+    resolution: {integrity: sha512-pgM+NanKseYNd+iT2nofTPUEMG3GIr81hn3UAxpDq38jij7auxT8+Kg4c5asGF+RFzdyH42V8w7TjXQwITFepQ==}
     peerDependencies:
-      '@mlightcad/common': 1.12.5
+      '@mlightcad/common': 1.13.0
 
-  '@mlightcad/graphic-interface@3.12.5':
-    resolution: {integrity: sha512-OW2TjScZbLLRfliOZhNlsInTKuTeP/hhVJ/7pEhbqN/huWBTB6fXKwojoE4OyLZUjDnCWJq0DBH1I+CGwPaPuQ==}
+  '@mlightcad/graphic-interface@3.13.0':
+    resolution: {integrity: sha512-e2IYhHp1XFmWADZ3vwsEp+drL2r+4wqB+y0jT10uOScCzBRZoP/sYXrQUGgSLAiRpBdlJ61DLOGoiZU4Jw51MA==}
     peerDependencies:
-      '@mlightcad/common': 1.12.5
-      '@mlightcad/geometry-engine': 3.12.5
+      '@mlightcad/common': 1.13.0
+      '@mlightcad/geometry-engine': 3.13.0
+
+  '@mlightcad/libredwg-converter@3.13.0':
+    resolution: {integrity: sha512-cozU8IdH3n6Yz7daQSl21EQrSQuhpVtb89Peqm5Wjl7bMJ5RYW4KKdkMr6xDmzXKq7Bb2TsoS6DRLwLLc4e7nQ==}
+    peerDependencies:
+      '@mlightcad/data-model': 1.13.0
+
+  '@mlightcad/libredwg-web@0.7.9':
+    resolution: {integrity: sha512-tqjx0eCiR0CNI3TyO3LVYzl4ptuzSFm7asGn/C1YiJaEk7Vneto+lRrVUco85qw+PZDihaFLwWqdYIEse1swbA==}
+    engines: {node: '>=20'}
 
   '@mlightcad/mtext-parser@1.5.0':
     resolution: {integrity: sha512-Yl/IQmSIGV1UUl/TyUptoOpNBunywcEE7yh4k9SFDXljHDTTI92VmqkVFxf4eYzhoWF4MNXIl4qgQV1P1Rbn6g==}
@@ -268,10 +280,10 @@ packages:
   '@mlightcad/shx-parser@1.4.5':
     resolution: {integrity: sha512-wFY0X7vnuq1IYdP6JRggb7LHcKho1P8zmcWGtXa6XYthwyKZCUoZCswTXr7J26pbzyhBB7KsiCcCL48iwIevdQ==}
 
-  '@mlightcad/three-renderer@1.5.11':
-    resolution: {integrity: sha512-3a9Vfvs7xC5VmkO5AXVYmNUlhbQ+sk5vuXZVJxSaa160DoJgDIWewZrOpV/aYmoKTBGTZgffBjOf6zRiL0NaWg==}
+  '@mlightcad/three-renderer@1.6.0':
+    resolution: {integrity: sha512-f3dHDYg6ttMEvlEeXB5Woydr0wT0/OX7hhXB2CYnrjFOVCGVKQyJCj+oEeijOFTdAiiZok6OxVLuwDlUdM/dPA==}
     peerDependencies:
-      '@mlightcad/data-model': ^1.12.5
+      '@mlightcad/data-model': ^1.13.0
       '@mlightcad/mtext-renderer': ^0.12.4
       '@velipso/polybool': ^1.1.1
       three: ^0.172.0
@@ -467,10 +479,6 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  fs-extra@11.3.2:
-    resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
-    engines: {node: '>=14.14'}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -483,9 +491,6 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
-
-  graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   iconv-lite@0.7.3:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
@@ -523,9 +528,6 @@ packages:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
 
-  jsonfile@6.2.0:
-    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
-
   lodash-es@4.17.21:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
 
@@ -550,8 +552,8 @@ packages:
     resolution: {integrity: sha512-kCyjv6xdDY1W/jLWZ/L3QhhTlKUqDZMQ5+Jdlw12b3dXkKNpYBqqlMMj0YDQPShWFTMwgZI1hG14kN3XUDSg/A==}
     hasBin: true
 
-  p-map@7.0.3:
-    resolution: {integrity: sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==}
+  p-map@7.0.6:
+    resolution: {integrity: sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==}
     engines: {node: '>=18'}
 
   picocolors@1.1.1:
@@ -563,6 +565,10 @@ packages:
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   postcss@8.5.6:
@@ -621,6 +627,10 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -637,15 +647,11 @@ packages:
     resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
     engines: {node: '>=8'}
 
-  universalify@2.0.1:
-    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
-    engines: {node: '>= 10.0.0'}
-
-  vite-plugin-static-copy@3.1.2:
-    resolution: {integrity: sha512-aVmYOzptLVOI2b1jL+cmkF7O6uhRv1u5fvOkQgbohWZp2CbR22kn9ZqkCUIt9umKF7UhdbsEpshn1rf4720QFg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite-plugin-static-copy@4.1.1:
+    resolution: {integrity: sha512-GrlA8YklrAfSyxJ4M3fdQLOo9oNkp56IM9FYgX/WtEgeIFkPwhu4wzpufBCIuNKCa6Fn77FkRdYxkHqV0FwjAw==}
+    engines: {node: ^22.0.0 || >=24.0.0}
     peerDependencies:
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   vite@6.4.3:
     resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
@@ -785,58 +791,65 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
-  '@mlightcad/cad-html-plugin@1.5.11(@mlightcad/cad-simple-viewer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.12.5)(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(three@0.172.0)':
+  '@mlightcad/cad-html-plugin@1.6.0(@mlightcad/cad-simple-viewer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.13.0)(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(three@0.172.0)':
     dependencies:
-      '@mlightcad/cad-simple-viewer': 1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0)
-      '@mlightcad/data-model': 1.12.5
-      '@mlightcad/three-renderer': 1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0)
+      '@mlightcad/cad-simple-viewer': 1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0)
+      '@mlightcad/data-model': 1.13.0
+      '@mlightcad/three-renderer': 1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0)
       three: 0.172.0
 
-  '@mlightcad/cad-pdf-plugin@1.5.11(@mlightcad/cad-simple-viewer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/cad-svg-plugin@1.5.11(@mlightcad/cad-simple-viewer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-parser@1.5.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0)))(@mlightcad/data-model@1.12.5)':
+  '@mlightcad/cad-pdf-plugin@1.6.0(@mlightcad/cad-simple-viewer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/cad-svg-plugin@1.6.0(@mlightcad/cad-simple-viewer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-parser@1.5.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0)))(@mlightcad/data-model@1.13.0)':
     dependencies:
-      '@mlightcad/cad-simple-viewer': 1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0)
-      '@mlightcad/cad-svg-plugin': 1.5.11(@mlightcad/cad-simple-viewer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-parser@1.5.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))
-      '@mlightcad/data-model': 1.12.5
+      '@mlightcad/cad-simple-viewer': 1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0)
+      '@mlightcad/cad-svg-plugin': 1.6.0(@mlightcad/cad-simple-viewer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-parser@1.5.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))
+      '@mlightcad/data-model': 1.13.0
 
-  '@mlightcad/cad-simple-ui-plugin@1.5.11(@mlightcad/cad-simple-viewer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.12.5)':
+  '@mlightcad/cad-simple-ui-plugin@1.6.0(@mlightcad/cad-simple-viewer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.13.0)':
     dependencies:
-      '@mlightcad/cad-simple-viewer': 1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0)
-      '@mlightcad/data-model': 1.12.5
+      '@mlightcad/cad-simple-viewer': 1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0)
+      '@mlightcad/data-model': 1.13.0
 
-  '@mlightcad/cad-simple-viewer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0)':
+  '@mlightcad/cad-simple-viewer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0)':
     dependencies:
-      '@mlightcad/data-model': 1.12.5
+      '@mlightcad/data-model': 1.13.0
       '@mlightcad/mtext-renderer': 0.12.4(three@0.172.0)
-      '@mlightcad/three-renderer': 1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0)
+      '@mlightcad/three-renderer': 1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0)
       lodash-es: 4.17.21
       three: 0.172.0
 
-  '@mlightcad/cad-svg-plugin@1.5.11(@mlightcad/cad-simple-viewer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-parser@1.5.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))':
+  '@mlightcad/cad-svg-plugin@1.6.0(@mlightcad/cad-simple-viewer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0))(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-parser@1.5.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))':
     dependencies:
-      '@mlightcad/cad-simple-viewer': 1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0)
-      '@mlightcad/data-model': 1.12.5
+      '@mlightcad/cad-simple-viewer': 1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0))(lodash-es@4.17.21)(three@0.172.0)
+      '@mlightcad/data-model': 1.13.0
       '@mlightcad/mtext-parser': 1.5.0
       '@mlightcad/mtext-renderer': 0.12.4(three@0.172.0)
 
-  '@mlightcad/common@1.12.5':
+  '@mlightcad/common@1.13.0':
     dependencies:
       loglevel: 1.9.2
 
-  '@mlightcad/data-model@1.12.5':
+  '@mlightcad/data-model@1.13.0':
     dependencies:
-      '@mlightcad/common': 1.12.5
-      '@mlightcad/geometry-engine': 3.12.5(@mlightcad/common@1.12.5)
-      '@mlightcad/graphic-interface': 3.12.5(@mlightcad/common@1.12.5)(@mlightcad/geometry-engine@3.12.5(@mlightcad/common@1.12.5))
+      '@mlightcad/common': 1.13.0
+      '@mlightcad/geometry-engine': 3.13.0(@mlightcad/common@1.13.0)
+      '@mlightcad/graphic-interface': 3.13.0(@mlightcad/common@1.13.0)(@mlightcad/geometry-engine@3.13.0(@mlightcad/common@1.13.0))
       uid: 2.0.2
 
-  '@mlightcad/geometry-engine@3.12.5(@mlightcad/common@1.12.5)':
+  '@mlightcad/geometry-engine@3.13.0(@mlightcad/common@1.13.0)':
     dependencies:
-      '@mlightcad/common': 1.12.5
+      '@mlightcad/common': 1.13.0
 
-  '@mlightcad/graphic-interface@3.12.5(@mlightcad/common@1.12.5)(@mlightcad/geometry-engine@3.12.5(@mlightcad/common@1.12.5))':
+  '@mlightcad/graphic-interface@3.13.0(@mlightcad/common@1.13.0)(@mlightcad/geometry-engine@3.13.0(@mlightcad/common@1.13.0))':
     dependencies:
-      '@mlightcad/common': 1.12.5
-      '@mlightcad/geometry-engine': 3.12.5(@mlightcad/common@1.12.5)
+      '@mlightcad/common': 1.13.0
+      '@mlightcad/geometry-engine': 3.13.0(@mlightcad/common@1.13.0)
+
+  '@mlightcad/libredwg-converter@3.13.0(@mlightcad/data-model@1.13.0)':
+    dependencies:
+      '@mlightcad/data-model': 1.13.0
+      '@mlightcad/libredwg-web': 0.7.9
+
+  '@mlightcad/libredwg-web@0.7.9': {}
 
   '@mlightcad/mtext-parser@1.5.0': {}
 
@@ -851,9 +864,9 @@ snapshots:
 
   '@mlightcad/shx-parser@1.4.5': {}
 
-  '@mlightcad/three-renderer@1.5.11(@mlightcad/data-model@1.12.5)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0)':
+  '@mlightcad/three-renderer@1.6.0(@mlightcad/data-model@1.13.0)(@mlightcad/mtext-renderer@0.12.4(three@0.172.0))(@velipso/polybool@1.1.1)(three@0.172.0)':
     dependencies:
-      '@mlightcad/data-model': 1.12.5
+      '@mlightcad/data-model': 1.13.0
       '@mlightcad/mtext-renderer': 0.12.4(three@0.172.0)
       '@velipso/polybool': 1.1.1
       three: 0.172.0
@@ -1010,15 +1023,13 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
-
-  fs-extra@11.3.2:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.0
-      universalify: 2.0.1
 
   fsevents@2.3.3:
     optional: true
@@ -1028,8 +1039,6 @@ snapshots:
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
-
-  graceful-fs@4.2.11: {}
 
   iconv-lite@0.7.3:
     dependencies:
@@ -1057,12 +1066,6 @@ snapshots:
     dependencies:
       is-docker: 2.2.1
 
-  jsonfile@6.2.0:
-    dependencies:
-      universalify: 2.0.1
-    optionalDependencies:
-      graceful-fs: 4.2.11
-
   lodash-es@4.17.21: {}
 
   loglevel@1.9.2: {}
@@ -1079,13 +1082,15 @@ snapshots:
 
   opentype.js@2.0.0: {}
 
-  p-map@7.0.3: {}
+  p-map@7.0.6: {}
 
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  picomatch@4.0.5: {}
 
   postcss@8.5.6:
     dependencies:
@@ -1159,6 +1164,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -1171,15 +1181,12 @@ snapshots:
     dependencies:
       '@lukeed/csprng': 1.1.0
 
-  universalify@2.0.1: {}
-
-  vite-plugin-static-copy@3.1.2(vite@6.4.3):
+  vite-plugin-static-copy@4.1.1(vite@6.4.3):
     dependencies:
       chokidar: 3.6.0
-      fs-extra: 11.3.2
-      p-map: 7.0.3
+      p-map: 7.0.6
       picocolors: 1.1.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
       vite: 6.4.3
 
   vite@6.4.3:

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import {
   scheduleViewerPreload
 } from './viewerLoader'
 import { WEBWORKER_FILE_URLS } from './workerConfig'
+import { registerLibreDwgConverter } from './registerLibreDwg'
 
 /**
  * Toast notification severity used by {@link CadViewerApp.showMessage}.
@@ -225,7 +226,8 @@ export class CadViewerApp {
    * before calling `createInstance`.
    *
    * Configuration highlights:
-   * - `webworkerFileUrls` — DWG parser and MTEXT worker scripts copied to `dist/assets/`
+   * - LibreDWG DWG converter — host-registered via {@link registerLibreDwgConverter} (GPL opt-in)
+   * - `webworkerFileUrls` — MTEXT + LibreDWG worker (+ wasm) copied to `dist/assets/`
    * - `checkWorkersOnInit` — probe worker URLs after registration (see {@link WEBWORKER_FILE_URLS})
    * - `baseUrl` — optional CDN root for built-in resources (demo override)
    * - `useMainThreadDraw` — MTEXT render mode; fixed for the lifetime of the page session
@@ -251,11 +253,14 @@ export class CadViewerApp {
     try {
       // Prefer the shared preload promise so first open awaits in-flight work
       await preloadViewerAppModules(this.enablePlugins)
-      const { AcApDocManager, AcEdCommandStack, applyUiTheme } =
+      const { AcApDocManager, AcEdCommandStack, acedApplyUiTheme } =
         await loadCadSimpleViewer()
       this.DocManager = AcApDocManager
 
-      applyUiTheme('dark', this.viewerPane)
+      acedApplyUiTheme('dark', this.viewerPane)
+
+      // Same pattern as cad-viewer monorepo example: register before createInstance.
+      registerLibreDwgConverter(String(WEBWORKER_FILE_URLS.dwgParser))
 
       const workersReachable = await AcApDocManager.checkWebworkerReadiness(
         WEBWORKER_FILE_URLS

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,7 +10,6 @@ import {
   scheduleViewerPreload
 } from './viewerLoader'
 import { WEBWORKER_FILE_URLS } from './workerConfig'
-import { registerLibreDwgConverter } from './registerLibreDwg'
 
 /**
  * Toast notification severity used by {@link CadViewerApp.showMessage}.
@@ -259,7 +258,8 @@ export class CadViewerApp {
 
       acedApplyUiTheme('dark', this.viewerPane)
 
-      // Same pattern as cad-viewer monorepo example: register before createInstance.
+      // Dynamic import keeps LibreDWG / data-model out of the app entry until first open.
+      const { registerLibreDwgConverter } = await import('./registerLibreDwg')
       registerLibreDwgConverter(String(WEBWORKER_FILE_URLS.dwgParser))
 
       const workersReachable = await AcApDocManager.checkWebworkerReadiness(

--- a/src/registerLibreDwg.ts
+++ b/src/registerLibreDwg.ts
@@ -1,0 +1,24 @@
+/**
+ * Opt into GPL LibreDWG DWG parsing for this example app.
+ * `@mlightcad/cad-simple-viewer` does not register a DWG converter by default.
+ */
+import {
+  AcDbDatabaseConverterManager,
+  AcDbFileType
+} from '@mlightcad/data-model'
+import { AcDbLibreDwgConverter } from '@mlightcad/libredwg-converter'
+
+/**
+ * Registers {@link AcDbLibreDwgConverter} for DWG open.
+ *
+ * @param parserWorkerUrl - Absolute or document-relative URL of
+ *   `libredwg-parser-worker.js` (wasm must sit next to that worker file)
+ */
+export function registerLibreDwgConverter(parserWorkerUrl: string): void {
+  const converter = new AcDbLibreDwgConverter({
+    convertByEntityType: false,
+    useWorker: true,
+    parserWorkerUrl
+  })
+  AcDbDatabaseConverterManager.instance.register(AcDbFileType.DWG, converter)
+}

--- a/src/viewerLoader.ts
+++ b/src/viewerLoader.ts
@@ -27,7 +27,7 @@ export function loadCadSimpleViewer(): Promise<CadSimpleViewerModule> {
 
 /**
  * Preloads the viewer package plus local modules needed on first open
- * (`i18n`, ellipse demo command, and optionally plugin registration).
+ * (`i18n`, ellipse demo command, LibreDWG registration, and optionally plugin registration).
  *
  * Safe to call multiple times; work is shared via a single promise.
  * Failed attempts clear the cached promise so a later open can retry.
@@ -38,7 +38,11 @@ export function preloadViewerAppModules(enablePlugins: boolean): Promise<void> {
   if (!appModulesPromise) {
     appModulesPromise = (async () => {
       await loadCadSimpleViewer()
-      const tasks: Promise<unknown>[] = [import('./i8n'), import('./ellipseCmd')]
+      const tasks: Promise<unknown>[] = [
+        import('./i8n'),
+        import('./ellipseCmd'),
+        import('./registerLibreDwg')
+      ]
       if (enablePlugins) {
         tasks.push(import('./register'))
       }

--- a/src/workerConfig.ts
+++ b/src/workerConfig.ts
@@ -1,14 +1,17 @@
 import type { AcApWebworkerFiles } from '@mlightcad/cad-simple-viewer'
 
+/** Local names — do not import from `@mlightcad/cad-simple-viewer` (keeps entry lean). */
+export const LIBREDWG_PARSER_WORKER_FILE = 'libredwg-parser-worker.js'
+export const LIBREDWG_PARSER_WASM_FILE = 'libredwg-web.wasm'
+export const MTEXT_RENDERER_WORKER_FILE = 'mtext-renderer-worker.js'
+
 /**
- * DWG parser and MTEXT worker script URLs for this example.
+ * MTEXT + LibreDWG worker URLs (same `assets/` folder as the JS bundles).
  *
- * DXF is parsed by the built-in converter in `@mlightcad/data-model` (no separate worker).
- * Vite copies the remaining worker files from `@mlightcad/cad-simple-viewer` into
- * `dist/assets/` (see `vite.config.ts`). Host apps must deploy the same files and
- * point `webworkerFileUrls` at their served paths before calling `openDocument()`.
+ * Vite copies these next to each other under `dist/assets/` so the LibreDWG
+ * worker can resolve `libredwg-web.wasm` via `import.meta.url`.
  */
 export const WEBWORKER_FILE_URLS: Required<AcApWebworkerFiles> = {
-  mtextRender: './assets/mtext-renderer-worker.js',
-  dwgParser: './assets/libredwg-parser-worker.js'
+  mtextRender: `./assets/${MTEXT_RENDERER_WORKER_FILE}`,
+  dwgParser: `./assets/${LIBREDWG_PARSER_WORKER_FILE}`
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,12 @@ import { defineConfig, type PluginOption } from 'vite'
 import { visualizer } from 'rollup-plugin-visualizer'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
 
+/** Mirror naming helpers from `@mlightcad/cad-simple-viewer` (not shipped there). */
+const LIBREDWG_CONVERTER_PACKAGE = '@mlightcad/libredwg-converter'
+const LIBREDWG_PARSER_WORKER_FILE = 'libredwg-parser-worker.js'
+const LIBREDWG_PARSER_WASM_FILE = 'libredwg-web.wasm'
+const MTEXT_RENDERER_WORKER_FILE = 'mtext-renderer-worker.js'
+
 /**
  * Split heavy peer deps into their own chunks so `cad-simple-viewer-*.js` stays
  * smaller and each package can be cached independently.
@@ -58,6 +64,15 @@ const viewerRuntimeSrc = resolve(
 )
 const hasViewerRuntime = existsSync(viewerRuntimeSrc)
 
+const libredwgDist = `./node_modules/${LIBREDWG_CONVERTER_PACKAGE}/dist`
+const libredwgWasmSrc = resolve(
+  __dirname,
+  'node_modules',
+  LIBREDWG_CONVERTER_PACKAGE,
+  'dist',
+  LIBREDWG_PARSER_WASM_FILE
+)
+
 if (!hasViewerRuntime) {
   console.warn(
     '[cad-simple-viewer-example] viewer-runtime.iife.js not found — HTML export (chtml) unavailable. ' +
@@ -83,14 +98,30 @@ export default defineConfig(({ mode }) => ({
     viteStaticCopy({
       targets: [
         {
-          src: './node_modules/@mlightcad/cad-simple-viewer/dist/*-worker.js',
-          dest: 'assets'
+          src: `./node_modules/@mlightcad/cad-simple-viewer/dist/${MTEXT_RENDERER_WORKER_FILE}`,
+          dest: 'assets',
+          rename: { stripBase: true }
         },
+        {
+          src: `${libredwgDist}/${LIBREDWG_PARSER_WORKER_FILE}`,
+          dest: 'assets',
+          rename: { stripBase: true }
+        },
+        ...(existsSync(libredwgWasmSrc)
+          ? [
+              {
+                src: `${libredwgDist}/${LIBREDWG_PARSER_WASM_FILE}`,
+                dest: 'assets',
+                rename: { stripBase: true }
+              }
+            ]
+          : []),
         ...(hasViewerRuntime
           ? [
               {
                 src: './node_modules/@mlightcad/cad-html-plugin/dist/viewer-runtime.iife.js',
-                dest: 'assets'
+                dest: 'assets',
+                rename: { stripBase: true }
               }
             ]
           : [])


### PR DESCRIPTION
## Summary
- Upgrade `@mlightcad/cad-simple-viewer` stack to **1.6.0** / `data-model` **1.13.0**, and rename `applyUiTheme` → `acedApplyUiTheme`.
- Make DWG support an explicit GPL opt-in: depend on `@mlightcad/libredwg-converter`, register via `src/registerLibreDwg.ts` before `createInstance`, and copy LibreDWG worker + wasm into `dist/assets/`.
- Bump `vite-plugin-static-copy` to v4 (`rename: { stripBase: true }`) and document the new worker/wasm deployment pattern in README.

## Test plan
- [ ] `pnpm install && pnpm build` — confirm 4 static assets copied (mtext worker, libredwg worker, wasm, viewer-runtime)
- [ ] `pnpm dev` — open DXF on both `index.html` and `no-plugin.html`
- [ ] Open a DWG and confirm LibreDWG worker + wasm load (no missing `.wasm` errors)
- [ ] With-plugins page: toolbar / Layer Manager / export still work
- [ ] Spot-check README snippets against `vite.config.ts` and `registerLibreDwg.ts`

Made with [Cursor](https://cursor.com)